### PR TITLE
Fixed variable reference in contentFormatToBinary function

### DIFF
--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -66,12 +66,12 @@ registerFormat('application/octet-stream', 42)
 registerFormat('application/exi', 47)
 registerFormat('application/json', 50)
 
-var contentFormatToBinary = function(result) {
-  result = formatsString[result]
-  if (!result)
-    throw new Error('Unknown Content-Format: ' + value)
+var contentFormatToBinary = function(name) {
+  var value = formatsString[name]
+  if (!value)
+    throw new Error('Unknown Content-Format: ' + name)
 
-  return result
+  return value
 }
 
 var contentFormatToString = function(value) {


### PR DESCRIPTION
When you set a non registered content format, the contentFormatToBinary function will throw an undefined exception because `value` is not defined. 
I updated to variable naming to fix this problem and to be more consistent with the rest of the code.