### PR TITLE
Original address

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,15 @@ following additional methods, events and properties.
 
 Closes the stream.
 
+#### message.rsinfo
+
+The sender informations, as emitted by the socket.
+See [the `dgram` docs](http://nodejs.org/api/dgram.html#dgram_event_message) for details
+
+#### message.outSocket
+
+Information about the socket used for the communication (address and port).
+
 -------------------------------------------------------
 <a name="observewrite"></a>
 ### ObserveWriteStream

--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ The URL of the request, e.g.
 The sender informations, as emitted by the socket.
 See [the `dgram` docs](http://nodejs.org/api/dgram.html#dgram_event_message) for details
 
+#### message.outSocket
+
+Information about the socket used for the communication (address and port).
+
+
 -------------------------------------------------------
 <a name="observeread"></a>
 ### ObserveReadStream

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -50,6 +50,7 @@ Agent.prototype._init = function initSock() {
   this._sock = dgram.createSocket(this._opts.type, function(msg, rsinfo) {
     var packet
       , message
+      , outSocket
 
     try {
       packet = parse(msg)
@@ -60,8 +61,8 @@ Agent.prototype._init = function initSock() {
       return
     }
 
-    rsinfo.localAddress = that._sock.address();
-    that._handle(msg, rsinfo)
+    outSocket = that._sock.address();
+    that._handle(msg, rsinfo, outSocket)
   })
 
   if(this._opts.port){
@@ -105,7 +106,7 @@ Agent.prototype._doClose = function() {
   this._sock = null
 }
 
-Agent.prototype._handle = function handle(msg, rsinfo) {
+Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
   var packet = parse(msg)
     , buf
     , response
@@ -227,7 +228,7 @@ Agent.prototype._handle = function handle(msg, rsinfo) {
       that._cleanUp()
     })
   } else {
-    response = new IncomingMessage(packet, rsinfo)
+    response = new IncomingMessage(packet, rsinfo, outSocket)
   }
 
   req.response = response

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -59,6 +59,8 @@ Agent.prototype._init = function initSock() {
                       rsinfo.port, rsinfo.address)
       return
     }
+
+    rsinfo.localAddress = that._sock.address();
     that._handle(msg, rsinfo)
   })
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -222,7 +222,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
     delete that._tkToReq[packet.token.readUInt32BE(0)]
 
   if (req.url.observe && packet.code !== '4.04') {
-    response = new ObserveStream(packet, rsinfo)
+    response = new ObserveStream(packet, rsinfo, outSocket)
     response.on('close', function() {
       delete that._tkToReq[packet.token.readUInt32BE(0)]
       that._cleanUp()

--- a/lib/incoming_message.js
+++ b/lib/incoming_message.js
@@ -10,13 +10,15 @@ var Readable  = require('stream').Readable
   , util      = require('util')
   , pktToMsg  = require('./helpers').packetToMessage
 
-function IncomingMessage(packet, rsinfo) {
+function IncomingMessage(packet, rsinfo, outSocket) {
   Readable.call(this)
 
   pktToMsg(this, packet)
 
+  this.rsinfo = rsinfo
+  this.outSocket = outSocket
+
   this._packet = packet
-  this._rsinfo = rsinfo
   this._payloadIndex = 0
 }
 

--- a/lib/incoming_message.js
+++ b/lib/incoming_message.js
@@ -10,12 +10,13 @@ var Readable  = require('stream').Readable
   , util      = require('util')
   , pktToMsg  = require('./helpers').packetToMessage
 
-function IncomingMessage(packet) {
+function IncomingMessage(packet, rsinfo) {
   Readable.call(this)
 
   pktToMsg(this, packet)
 
   this._packet = packet
+  this._rsinfo = rsinfo
   this._payloadIndex = 0
 }
 

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -10,8 +10,11 @@ var Readable  = require('stream').Readable
   , util      = require('util')
   , pktToMsg  = require('./helpers').packetToMessage
 
-function ObserveReadStream(packet) {
+function ObserveReadStream(packet, rsinfo, outSocket) {
   Readable.call(this, { objectMode: true })
+
+  this.rsinfo = rsinfo
+  this.outSocket = outSocket
 
   this._lastId = 0
   this.append(packet)

--- a/test/request.js
+++ b/test/request.js
@@ -569,8 +569,9 @@ describe('request', function() {
 
     req.on('response', function(res) {
       expect(res).to.have.property('_rsinfo')
-      expect(res._rsinfo).to.have.property('address')
-      expect(res._rsinfo).to.have.property('port')
+      expect(res._rsinfo).to.have.property('localAddress')
+      expect(res._rsinfo.localAddress).to.have.property('address')
+      expect(res._rsinfo.localAddress).to.have.property('port')
       done()
     })
 

--- a/test/request.js
+++ b/test/request.js
@@ -552,7 +552,7 @@ describe('request', function() {
     req.end()
   })
 
-  it('should include original socket information in the response', function(done) {
+  it('should include original and destination socket information in the response', function(done) {
     var req = request({
       port: port
     })
@@ -568,10 +568,10 @@ describe('request', function() {
     })
 
     req.on('response', function(res) {
-      expect(res).to.have.property('_rsinfo')
-      expect(res._rsinfo).to.have.property('localAddress')
-      expect(res._rsinfo.localAddress).to.have.property('address')
-      expect(res._rsinfo.localAddress).to.have.property('port')
+      expect(res).to.have.property('rsinfo')
+      expect(res).to.have.property('outSocket')
+      expect(res.outSocket).to.have.property('address')
+      expect(res.outSocket).to.have.property('port')
       done()
     })
 

--- a/test/request.js
+++ b/test/request.js
@@ -552,6 +552,31 @@ describe('request', function() {
     req.end()
   })
 
+  it('should include original socket information in the response', function(done) {
+    var req = request({
+      port: port
+    })
+
+    server.on('message', function(msg, rsinfo) {
+      var packet  = parse(msg)
+          , toSend  = generate({
+            messageId: packet.messageId
+            , token: packet.token
+            , options: []
+          })
+      server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
+    })
+
+    req.on('response', function(res) {
+      expect(res).to.have.property('_rsinfo')
+      expect(res._rsinfo).to.have.property('address')
+      expect(res._rsinfo).to.have.property('port')
+      done()
+    })
+
+    req.end()
+  })
+
   describe('non-confirmable retries', function() {
     var clock
 

--- a/test/request.js
+++ b/test/request.js
@@ -860,6 +860,22 @@ describe('request', function() {
       })
     })
 
+    it('should send origin and destination socket data along with the response', function(done) {
+
+      var req = doObserve()
+
+      req.on('response', function(res) {
+        res.once('data', function(data) {
+          expect(res).to.have.property('rsinfo')
+          expect(res).to.have.property('outSocket')
+          expect(res.outSocket).to.have.property('address')
+          expect(res.outSocket).to.have.property('port')
+          res.close()
+          done()
+        })
+      })
+    })
+
     it('should emit any more data after close', function(done) {
 
       var req = doObserve()


### PR DESCRIPTION
Add a property in the response listener for the requests to allow the caller to retrieve information about the socket used in the communication (port, address and protocol). This addition was motivated by the need of identifying the device original address in COAP-based OMA Lightweight M2M protocol as explained in issue #39 (originally the need was to use the same socket for listening and sending requests, but having information about the registration socket might lead to avoid the sharing, as explained in a comment).

I choose to expose the information as part of the `rsinfo` object (that was already passed to the IncomingMessage instance creation) and expose the latter in a `_rsinfo` internal attribute of the response, but I'm not 100% confident this is the best option. It covers the functionality specified in the issue, though.