### PR TITLE
Add reset method

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ following additional methods and properties.
 Emitted when the client is not sending 'acks' anymore for the sent
 messages.
 
+#### reset()
+Returns a Reset COAP Message to the sender. The RST message will appear as an empty message with code `0.00` and the
+reset flag set to `true` to the caller. This action ends the interaction with the caller.
+
 -------------------------------------------------------
 <a name="registerOption"></a>
 ### coap.registerOption(name, toBinary, toString)

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ See the
 [spec](http://tools.ietf.org/html/draft-ietf-core-coap-18#section-5.4)
 for all the possible options.
 
+#### message.reset()
+Returns a Reset COAP Message to the sender. The RST message will appear as an empty message with code `0.00` and the
+reset flag set to `true` to the caller. This action ends the interaction with the caller.
 -------------------------------------------------------
 <a name="incoming"></a>
 ### IncomingMessage

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ __node-coap__ is only possible due to the excellent work of the following contri
 <table><tbody>
 <tr><th align="left">Matteo Collina</th><td><a href="https://github.com/mcollina">GitHub/mcollina</a></td><td><a href="https://twitter.com/matteocollina">Twitter/@matteocollina</a></td></tr>
 <tr><th align="left">Nguyen Quoc Dinh</th><td><a href="https://github.com/nqd">GitHub/nqd</a></td><td><a href="https://twitter.com/nqdinh">Twitter/@nqdinh</a></td></tr>
+<tr><th align="left">Daniel Moran Jimenez</th><td><a href="https://github.com/dmoranj">GitHub/nqd</a></td><td><a href="https://twitter.com/erzeneca">Twitter/@erzeneca</a></td></tr>
 </tbody></table>
 
 ## LICENSE

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -63,4 +63,19 @@ ObserveWriteStream.prototype._doSend = function doSend(data) {
   delete this._packet.payload
 }
 
+ObserveWriteStream.prototype.reset = function reset() {
+  var packet = this._packet
+  packet.code = '0.00'
+  packet.payload = ''
+  packet.reset = true;
+  packet.ack = false
+  packet.token = new Buffer(0);
+
+  this._send(this, packet)
+
+  this._packet.confirmable = this._request.confirmable
+  delete this._packet.messageId
+  delete this._packet.payload
+}
+
 module.exports = ObserveWriteStream

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -76,4 +76,27 @@ OutgoingMessage.prototype.end = function(a, b) {
   return this
 }
 
+OutgoingMessage.prototype.reset = function() {
+  BufferList.prototype.end.call(this)
+
+  var packet = this._packet
+    , message
+    , that = this
+
+  packet.code = '0.00'
+  packet.payload = ''
+  packet.reset = true;
+  packet.ack = false
+
+  this._send(this, packet)
+
+  // easy clean up after generating the packet
+  delete this._packet.payload
+
+  if (this._ackTimer)
+    clearTimeout(this._ackTimer)
+
+  return this
+}
+
 module.exports = OutgoingMessage

--- a/test/server.js
+++ b/test/server.js
@@ -16,7 +16,7 @@ var coap      = require('../')
   , sinon     = require('sinon')
   , params    = require('../lib/parameters')
 
-describe('server', function() {
+describe.only('server', function() {
   var server
     , port
     , clientPort
@@ -212,6 +212,23 @@ describe('server', function() {
     server.on('request', function(req, res) {
       expect(req.options).to.eql(options)
       done()
+    })
+  })
+
+  // TODO
+  it('should include a reset() function in the response', function(done) {
+    var buf = new Buffer(25)
+    send(generate({ payload: buf }))
+    client.on('message', function(msg, rinfo) {
+      var result = parse(msg)
+      expect(result.code).to.eql('0.00')
+      expect(result.reset).to.eql(true)
+      expect(result.ack).to.eql(false)
+      expect(result.payload.length).to.eql(0)
+      done()
+    });
+    server.on('request', function(req, res) {
+      res.reset()
     })
   })
 

--- a/test/server.js
+++ b/test/server.js
@@ -778,6 +778,25 @@ describe.only('server', function() {
       })
     })
 
+    it('should send a \'RST\' to the client if the msg.reset() method is invoked', function(done) {
+      var now = Date.now()
+      doObserve()
+
+      server.on('request', function(req, res) {
+        res.reset()
+      })
+
+      client.on('message', function(msg) {
+        var result = parse(msg)
+        expect(result.code).to.eql('0.00')
+        expect(result.reset).to.eql(true)
+        expect(result.ack).to.eql(false)
+        expect(result.payload.length).to.eql(0)
+
+        done();
+      })
+    })
+
     it('should correctly generate two-byte long sequence numbers', function(done) {
       var now = Date.now()
         , buf = new Buffer(2)

--- a/test/server.js
+++ b/test/server.js
@@ -16,7 +16,7 @@ var coap      = require('../')
   , sinon     = require('sinon')
   , params    = require('../lib/parameters')
 
-describe.only('server', function() {
+describe('server', function() {
   var server
     , port
     , clientPort
@@ -215,7 +215,6 @@ describe.only('server', function() {
     })
   })
 
-  // TODO
   it('should include a reset() function in the response', function(done) {
     var buf = new Buffer(25)
     send(generate({ payload: buf }))


### PR DESCRIPTION
Add a Reset method to the Outgoing message, so a COAP RST message can be returned to the caller.