### PR TITLE
Server shut down on unexpected option

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -103,7 +103,11 @@ CoAPServer.prototype.listen = function(port, address, done) {
       return that._sendError(new Buffer('Unable to parse packet'), rsinfo)
     }
 
-    that._handle(packet, rsinfo)
+    try {
+      that._handle(packet, rsinfo)
+    } catch(err) {
+      return that._sendError(new Buffer(err.message), rsinfo)
+    }
   })
 
   this._sock.bind(port, address || null, done || null)

--- a/test/server.js
+++ b/test/server.js
@@ -277,6 +277,30 @@ describe('server', function() {
     }
   })
 
+  describe('with the \'Content-Format\' header and a wrong value in the request', function() {
+    it('should return a 5.00 error to the cliend', function(done) {
+      send(generate({
+        options: [{
+          name: 'Content-Format'
+          , value: new Buffer([1541])
+        }]
+      }))
+
+      client.on('message', function(msg) {
+        var response = parse(msg);
+
+        expect(response.code).to.equal('5.00')
+        expect(response.payload.toString()).to.equal('No matching format found')
+
+        done()
+      })
+
+      server.on('request', function(req) {
+        assert(false, 'This should not happen')
+      })
+    })
+  })
+
   describe('with a non-confirmable message', function() {
     var packet = {
         confirmable: false


### PR DESCRIPTION
With the current behavior, an incoming request with an unknown 'Content-Format' option generates an unexpected exception that makes the server crash. I've captured the exceptions in the message handling, to return an error to the user, indicating that the request could not be handled.