### PR TITLE
Single socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ __node-coap__ is a client and server library for CoAP modelled after the `http` 
   * <a href="#intro">Introduction</a>
   * <a href="#install">Installation</a>
   * <a href="#basic">Basic Example</a>
+  * <a href="#proxy">Proxy features</a>
   * <a href="#api">API</a>
   * <a href="#contributing">Contributing</a>
   * <a href="#licence">Licence &amp; copyright</a>
@@ -103,6 +104,23 @@ server.listen(function() {
   req.end()
 })
 ```
+<a name="proxy"></a>
+## Proxy features
+The library now comes with the ability to behave as a COAP proxy for other COAP endpoints. In order to activate the
+proxy features, create the server with the `proxy` option activated.
+
+A proxy-enabled service behaves as usual for all requests, except for those coming with the `Proxy-Uri` option. This
+requests will be redirected to the URL specified in the option, and the response from this option will, in turn,  be
+redirected to the caller. In this case, the proxy server handler is not called at all (redirection is automatic).
+
+You can find an example of how this mechanism works in `examples/proxy.js`. This example features one target server
+that writes all the information it receives along with the origin port and a proxy server. Once the servers are up:
+
+- Ten requests are sent directly to the server (without reusing ports)
+- Ten requests are sent through the proxy (without reusing ports)
+
+The example shows that the target server sees the last ten requests as coming from the same port (the proxy), while the
+first ten come from different ports.
 
 <a name="api"></a>
 ## API

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The constructor can be given an optional options object, containing one of the f
 * `type`: indicates if the server should create IPv4 connections (`udp4`) or IPv6 connections (`udp6`). Defaults
   to `udp4`.
 * `proxy`: indicates that the server should behave like a proxy for incoming requests containing the `Proxy-Uri` header.
-  Defaults to `false`.
+  An example of how the proxy feature works, refer to the example in the `/examples` folder. Defaults to `false`.
 
 
 #### Event: 'request'

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ If it is an object:
   * [`Agent`](#agent) object: explicitly use the passed in [`Agent`](#agent).
   * `false`: opts out of socket reuse with an [`Agent`](#agent), each request uses a
     new UDP socket.
+- `proxyUri`: adds the Proxy-Uri option to the request, so if the request is sent to a
+  proxy (or a server with proxy features) the request will be forwarded to the selected URI.
+  The expected value is the URI of the target. E.g.: 'coap://192.168.5.13:6793'
 
 `coap.request()` returns an instance of <a
 href='#incoming'><code>OutgoingMessage</code></a>.
@@ -179,12 +182,19 @@ Which represent the updates coming from the server, according to the
 
 -------------------------------------------------------
 <a name="createServer"></a>
-### createServer([requestListener])
+### createServer([options], [requestListener])
 
 Returns a new CoAP Server object.
 
 The `requestListener` is a function which is automatically
 added to the `'request'` event.
+
+The constructor can be given an optional options object, containing one of the following options:
+* `type`: indicates if the server should create IPv4 connections (`udp4`) or IPv6 connections (`udp6`). Defaults
+  to `udp4`.
+* `proxy`: indicates that the server should behave like a proxy for incoming requests containing the `Proxy-Uri` header.
+  Defaults to `false`.
+
 
 #### Event: 'request'
 

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -1,0 +1,98 @@
+const
+    coap = require('../'),
+    async = require('async'),
+    Readable = require('stream').Readable,
+    requestNumber = 10;
+
+var targetServer,
+    proxy,
+    client1,
+    client2,
+    targetResults;
+
+function formatTitle(msg) {
+    return '\n\n' + msg + '\n-------------------------------------';
+}
+
+function requestHandler(req, res) {
+    console.log('Target receives [%s] in port [8976] from port [%s]', req.payload, req.rsinfo.port);
+    res.end('RES_' + req.payload);
+}
+
+function createTargetServer(callback) {
+    console.log('Creating target server at port 8976');
+
+    targetServer = coap.createServer(requestHandler);
+
+    targetServer.listen(8976, '0.0.0.0', callback);
+}
+
+function proxyHandler(req, res) {
+    console.log('Proxy handled [%s]', req.payload);
+    res.end('RES_' + req.payload);
+}
+
+function createProxy(callback) {
+    console.log('Creating proxy at port 6780');
+
+    proxy = coap.createServer({ proxy: true }, proxyHandler);
+
+    proxy.listen(6780, '0.0.0.0', callback);
+}
+
+function sendRequest(proxied) {
+    return function(n, callback) {
+        var req = {
+                host: 'localhost',
+                port: 8976,
+                agent: false
+            },
+            rs = new Readable();
+
+        if (proxied) {
+            req.port = 6780;
+            req.proxyUri = 'coap://localhost:8976';
+        }
+
+        request = coap.request(req);
+
+        request.on('response', function(res) {
+            console.log('Client receives [%s] in port [%s] from [%s]', res.payload, res.outSocket.port, res.rsinfo.port);
+            callback();
+        });
+
+        rs.push('MSG_' + n);
+        rs.push(null);
+        rs.pipe(request);
+    }
+}
+
+function executeTest(proxied) {
+    return function(callback) {
+        if (proxied) {
+            console.log(formatTitle('Executing tests with proxy'));
+        } else {
+            console.log(formatTitle('Executing tests without proxy'));
+        }
+
+        async.times(requestNumber, sendRequest(proxied), callback);
+    }
+}
+
+function cleanUp(callback) {
+    targetServer.close(function () {
+        proxy.close(callback);
+    });
+}
+
+function checkResults(callback) {
+    console.log(formatTitle('Finish'));
+}
+
+async.series([
+    createTargetServer,
+    createProxy,
+    executeTest(false),
+    executeTest(true),
+    cleanUp
+], checkResults);

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -304,6 +304,10 @@ Agent.prototype.request = function request(url) {
     }
   }
 
+  if (url.proxyUri) {
+    req.setOption('Proxy-Uri', url.proxyUri)
+  }
+
   req.sender.on('error', req.emit.bind(req, 'error'))
 
   req.sender.on('sending', function() {

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2013-2015 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
+var dgram           = require('dgram')
+  , net             = require('net')
+  , util            = require('util')
+  , async           = require('async')
+  , crypto          = require('crypto')
+  , events          = require('events')
+  , LRU             = require('lru-cache')
+  , parse           = require('coap-packet').parse
+  , generate        = require('coap-packet').generate
+  , IncomingMessage = require('./incoming_message')
+  , OutgoingMessage = require('./outgoing_message')
+  , ObserveStream   = require('./observe_write_stream')
+  , parameters      = require('./parameters')
+  , RetrySend       = require('./retry_send')
+  , parseBlock2     = require('./helpers').parseBlock2
+  , createBlock2    = require('./helpers').createBlock2
+  , getOption       = require('./helpers').getOption
+
+function parseRequest(request, next) {
+  try {
+    request.packet = parse(request.raw)
+    next(null)
+  } catch (err) {
+    next(new Buffer('Unable to parse packet'))
+  }
+}
+
+function handleServerRequest(request, next) {
+  try {
+    request.server._handle(request.packet, request.rsinfo)
+    next(new Buffer(''), true)
+  } catch (err) {
+    next(new Buffer(err.message))
+  }
+}
+
+function proxyRequest(request, next) {
+  for (var i = 0; i < request.packet.options.length; i++) {
+    if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
+      request.proxy = request.packet.options[i].value.toString()
+    }
+  }
+
+  if (request.proxy) {
+    if (request.packet.token.length === 0) {
+      request.packet.token = crypto.randomBytes(8);
+
+    }
+
+    request.server._proxiedRequests[request.packet.token.toString('hex')] = request
+    request.server._sendProxied(request.packet, request.proxy, function(error, message) {
+      if (error) {
+        next(new Buffer(error.message))
+      } else {
+        next(new Buffer(''), true)
+      }
+    })
+  } else {
+    next()
+  }
+}
+
+function handleProxyResponse(request, next) {
+  var originalProxiedRequest = request.server._proxiedRequests[request.packet.token.toString('hex')]
+  if ( originalProxiedRequest ) {
+    request.server._sendReverseProxied(request.packet, originalProxiedRequest.rsinfo)
+    delete request.server._proxiedRequests[request.packet.token.toString('hex')]
+    next(new Buffer(''), true)
+  } else {
+    next()
+  }
+}
+
+exports.parseRequest = parseRequest
+exports.handleServerRequest = handleServerRequest
+exports.proxyRequest = proxyRequest
+exports.handleProxyResponse = handleProxyResponse
+

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -55,9 +55,19 @@ var formatsString = {}
 var formatsBinaries = {}
 
 var registerFormat = function(name, value) {
-  formatsString[name] = new Buffer([value])
+  var bytes;
+
+  if (value > 255) {
+    bytes = new Buffer(2);
+    bytes.writeUInt16BE(value, 0);
+  } else {
+    bytes = new Buffer([value])
+  }
+
+  formatsString[name] = bytes
   formatsBinaries[value] = name
 }
+
 module.exports.registerFormat = registerFormat
 
 registerFormat('text/plain', 0)

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -48,6 +48,7 @@ var toString = function(value) {
 registerOption('ETag', fromString, toString)
 registerOption('Location-Path', fromString, toString)
 registerOption('Location-Query', fromString, toString)
+registerOption('Proxy-Uri', fromString, toString)
 
 // Content-Format and Accept options registration
 var formatsString = {}

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,6 +10,7 @@ var dgram           = require('dgram')
   , net             = require('net')
   , util            = require('util')
   , async           = require('async')
+  , crypto          = require('crypto')
   , events          = require('events')
   , LRU             = require('lru-cache')
   , parse           = require('coap-packet').parse
@@ -37,6 +38,7 @@ function CoAPServer(options, listener) {
     options = {}
 
   this._options = options
+  this._proxiedRequests = {}
 
   // We use an LRU cache for the responses to avoid
   // DDOS problems.
@@ -70,19 +72,27 @@ CoAPServer.prototype._sendProxied = function(packet, proxyUri) {
   var url = require('url').parse(proxyUri)
     , host = url.hostname
     , port = url.port
-    , path = url.path
     , message = generate({
       code: packet.code,
-      payload: packet.payload
+      payload: packet.payload,
+      token: packet.token
     })
 
   this._sock.send(message, 0, message.length, port, host)
 }
 
+CoAPServer.prototype._sendReverseProxied = function(packet, rsinfo) {
+  var host = rsinfo.address
+    , port = rsinfo.port
+    , message = generate(packet)
+
+  this._sock.send(message, 0, message.length, port, host)
+}
+
 function handleRequest(server) {
-  function handleError(request, error) {
-    if (error) {
-      server._sendError(error, request.rsinfo)
+  function handleEnding(request, message) {
+    if (message.toString() !== 'end') {
+      server._sendError(message, request.rsinfo)
     }
   }
 
@@ -98,28 +108,41 @@ function handleRequest(server) {
   function handleServerRequest(request, next) {
     try {
       server._handle(request.packet, request.rsinfo)
-      next()
+      next('end')
     } catch (err) {
       next(new Buffer(err.message))
     }
   }
 
   function proxyRequest(request, next) {
-    if (request.proxy) {
-      server._sendProxied(request.packet, request.proxy)
-    } else {
-      next()
-    }
-  }
-
-  function checkProxy(request, next) {
     for (var i = 0; i < request.packet.options.length; i++) {
       if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
         request.proxy = request.packet.options[i].value.toString()
       }
     }
 
-    next()
+    if (request.proxy) {
+      if (request.packet.token.length === 0) {
+        request.packet.token = crypto.randomBytes(8);
+
+      }
+      server._sendProxied(request.packet, request.proxy)
+      server._proxiedRequests[request.packet.token.toString('hex')] = request
+      next('end')
+    } else {
+      next()
+    }
+  }
+
+  function handleProxyResponse(request, next) {
+    var originalProxiedRequest = server._proxiedRequests[request.packet.token.toString('hex')]
+    if ( originalProxiedRequest ) {
+      server._sendReverseProxied(request.packet, originalProxiedRequest.rsinfo)
+      delete server._proxiedRequests[request.packet.token.toString('hex')]
+      next('end')
+    } else {
+      next()
+    }
   }
 
   return function (msg, rsinfo) {
@@ -130,10 +153,10 @@ function handleRequest(server) {
 
     async.series([
       async.apply(parseRequest, request),
-      async.apply(checkProxy, request),
       async.apply(proxyRequest, request),
+      async.apply(handleProxyResponse, request),
       async.apply(handleServerRequest, request)
-    ], async.apply(handleError, request))
+    ], async.apply(handleEnding, request))
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,63 +23,15 @@ var dgram           = require('dgram')
   , parseBlock2     = require('./helpers').parseBlock2
   , createBlock2    = require('./helpers').createBlock2
   , getOption       = require('./helpers').getOption
+  , middlewares     = require('./middlewares')
 
-function handleEnding(request, message) {
-  if (message.toString() !== 'end') {
-    request.server._sendError(message, request.rsinfo)
+function handleEnding(request, message, results) {
+  if (!results.pop()) {
+    request.server._sendError(message, request.rsinfo, request.packet)
   }
 }
 
-function parseRequest(request, next) {
-  try {
-    request.packet = parse(request.raw)
-    next(null)
-  } catch (err) {
-    next(new Buffer('Unable to parse packet'))
-  }
-}
-
-function handleServerRequest(request, next) {
-  try {
-    request.server._handle(request.packet, request.rsinfo)
-    next('end')
-  } catch (err) {
-    next(new Buffer(err.message))
-  }
-}
-
-function proxyRequest(request, next) {
-  for (var i = 0; i < request.packet.options.length; i++) {
-    if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
-      request.proxy = request.packet.options[i].value.toString()
-    }
-  }
-
-  if (request.proxy) {
-    if (request.packet.token.length === 0) {
-      request.packet.token = crypto.randomBytes(8);
-
-    }
-    request.server._sendProxied(request.packet, request.proxy)
-    request.server._proxiedRequests[request.packet.token.toString('hex')] = request
-    next('end')
-  } else {
-    next()
-  }
-}
-
-function handleProxyResponse(request, next) {
-  var originalProxiedRequest = request.server._proxiedRequests[request.packet.token.toString('hex')]
-  if ( originalProxiedRequest ) {
-    request.server._sendReverseProxied(request.packet, originalProxiedRequest.rsinfo)
-    delete request.server._proxiedRequests[request.packet.token.toString('hex')]
-    next('end')
-  } else {
-    next()
-  }
-}
-
-function CoAPServer(options, listener) {
+function CoAPServer(options, listener, errorListener) {
   if (!(this instanceof CoAPServer)) {
     return new CoAPServer(options)
   }
@@ -96,15 +48,15 @@ function CoAPServer(options, listener) {
   this._proxiedRequests = {}
 
   this._middlewares = [
-    parseRequest
+    middlewares.parseRequest
   ]
 
   if (options.proxy) {
-    this._middlewares.push(proxyRequest)
-    this._middlewares.push(handleProxyResponse)
+    this._middlewares.push(middlewares.proxyRequest)
+    this._middlewares.push(middlewares.handleProxyResponse)
   }
 
-  this._middlewares.push(handleServerRequest)
+  this._middlewares.push(middlewares.handleServerRequest)
 
   // We use an LRU cache for the responses to avoid
   // DDOS problems.
@@ -128,10 +80,15 @@ function CoAPServer(options, listener) {
 
 util.inherits(CoAPServer, events.EventEmitter)
 
-CoAPServer.prototype._sendError = function(payload, rsinfo) {
-  var message = generate({ code: '5.00', payload: payload })
-  this._sock.send(message, 0, message.length,
-                  rsinfo.port, rsinfo.address)
+CoAPServer.prototype._sendError = function(payload, rsinfo, packet) {
+  var message = generate({
+    code: '5.00',
+    payload: payload,
+    messageId: (packet)?packet.messageId:undefined,
+    token: (packet)?packet.token:undefined
+  })
+
+  this._sock.send(message, 0, message.length, rsinfo.port)
 }
 
 function removeProxyOptions(packet) {
@@ -148,25 +105,24 @@ function removeProxyOptions(packet) {
   return packet;
 }
 
-CoAPServer.prototype._sendProxied = function(packet, proxyUri) {
+CoAPServer.prototype._sendProxied = function(packet, proxyUri, callback) {
   var url = require('url').parse(proxyUri)
     , host = url.hostname
     , port = url.port
     , message = generate(removeProxyOptions(packet))
 
-  this._sock.send(message, 0, message.length, port, host)
+  this._sock.send(message, 0, message.length, port, host, callback)
 }
 
-CoAPServer.prototype._sendReverseProxied = function(packet, rsinfo) {
+CoAPServer.prototype._sendReverseProxied = function(packet, rsinfo, callback) {
   var host = rsinfo.address
     , port = rsinfo.port
     , message = generate(packet)
 
-  this._sock.send(message, 0, message.length, port, host)
+  this._sock.send(message, 0, message.length, port, host, callback)
 }
 
 function handleRequest(server) {
-
   return function (msg, rsinfo) {
     var request = {
         raw: msg,
@@ -184,6 +140,8 @@ function handleRequest(server) {
 }
 
 CoAPServer.prototype.listen = function(port, address, done) {
+  var that = this
+
   if (port == undefined) {
     port = parameters.coapPort
   }
@@ -210,6 +168,10 @@ CoAPServer.prototype.listen = function(port, address, done) {
     this._options.type = 'udp4'
 
   this._sock = dgram.createSocket(this._options.type, handleRequest(this))
+
+  this._sock.on('error', function(error) {
+    that.emit('error', error)
+  })
 
   this._sock.bind(port, address || null, done || null)
   this._port = port

--- a/lib/server.js
+++ b/lib/server.js
@@ -134,15 +134,25 @@ CoAPServer.prototype._sendError = function(payload, rsinfo) {
                   rsinfo.port, rsinfo.address)
 }
 
+function removeProxyOptions(packet) {
+  var cleanOptions = []
+
+  for (var i = 0; i < packet.options.length; i++) {
+    if (packet.options[i].name !== 'Proxy-uri' && packet.options[i].name !== 'Proxy-scheme') {
+      cleanOptions.push(packet.options[i])
+    }
+  }
+
+  packet.options = cleanOptions
+
+  return packet;
+}
+
 CoAPServer.prototype._sendProxied = function(packet, proxyUri) {
   var url = require('url').parse(proxyUri)
     , host = url.hostname
     , port = url.port
-    , message = generate({
-      code: packet.code,
-      payload: packet.payload,
-      token: packet.token
-    })
+    , message = generate(removeProxyOptions(packet))
 
   this._sock.send(message, 0, message.length, port, host)
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,7 @@
 var dgram           = require('dgram')
   , net             = require('net')
   , util            = require('util')
+  , async           = require('async')
   , events          = require('events')
   , LRU             = require('lru-cache')
   , parse           = require('coap-packet').parse
@@ -53,8 +54,6 @@ function CoAPServer(options, listener) {
                 }
   })
 
-
-
   if (listener)
     this.on('request', listener)
 }
@@ -65,6 +64,77 @@ CoAPServer.prototype._sendError = function(payload, rsinfo) {
   var message = generate({ code: '5.00', payload: payload })
   this._sock.send(message, 0, message.length,
                   rsinfo.port, rsinfo.address)
+}
+
+CoAPServer.prototype._sendProxied = function(packet, proxyUri) {
+  var url = require('url').parse(proxyUri)
+    , host = url.hostname
+    , port = url.port
+    , path = url.path
+    , message = generate({
+      code: packet.code,
+      payload: packet.payload
+    })
+
+  this._sock.send(message, 0, message.length, port, host)
+}
+
+function handleRequest(server) {
+  function handleError(request, error) {
+    if (error) {
+      server._sendError(error, request.rsinfo)
+    }
+  }
+
+  function parseRequest(request, next) {
+    try {
+      request.packet = parse(request.raw)
+      next(null)
+    } catch (err) {
+      next(new Buffer('Unable to parse packet'))
+    }
+  }
+
+  function handleServerRequest(request, next) {
+    try {
+      server._handle(request.packet, request.rsinfo)
+      next()
+    } catch (err) {
+      next(new Buffer(err.message))
+    }
+  }
+
+  function proxyRequest(request, next) {
+    if (request.proxy) {
+      server._sendProxied(request.packet, request.proxy)
+    } else {
+      next()
+    }
+  }
+
+  function checkProxy(request, next) {
+    for (var i = 0; i < request.packet.options.length; i++) {
+      if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
+        request.proxy = request.packet.options[i].value.toString()
+      }
+    }
+
+    next()
+  }
+
+  return function (msg, rsinfo) {
+    var request = {
+        raw: msg,
+        rsinfo: rsinfo
+      }
+
+    async.series([
+      async.apply(parseRequest, request),
+      async.apply(checkProxy, request),
+      async.apply(proxyRequest, request),
+      async.apply(handleServerRequest, request)
+    ], async.apply(handleError, request))
+  }
 }
 
 CoAPServer.prototype.listen = function(port, address, done) {
@@ -93,22 +163,7 @@ CoAPServer.prototype.listen = function(port, address, done) {
   if (!this._options.type)
     this._options.type = 'udp4'
 
-  var that = this
-
-  this._sock = dgram.createSocket(this._options.type, function(msg, rsinfo) {
-    var packet
-    try {
-      packet = parse(msg)
-    } catch(err) {
-      return that._sendError(new Buffer('Unable to parse packet'), rsinfo)
-    }
-
-    try {
-      that._handle(packet, rsinfo)
-    } catch(err) {
-      return that._sendError(new Buffer(err.message), rsinfo)
-    }
-  })
+  this._sock = dgram.createSocket(this._options.type, handleRequest(this))
 
   this._sock.bind(port, address || null, done || null)
   this._port = port

--- a/lib/server.js
+++ b/lib/server.js
@@ -95,7 +95,7 @@ function removeProxyOptions(packet) {
   var cleanOptions = []
 
   for (var i = 0; i < packet.options.length; i++) {
-    if (packet.options[i].name !== 'Proxy-uri' && packet.options[i].name !== 'Proxy-scheme') {
+    if (packet.options[i].name.toLowerCase() !== 'proxy-uri' && packet.options[i].name.toLowerCase() !== 'proxy-scheme') {
       cleanOptions.push(packet.options[i])
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,6 +24,61 @@ var dgram           = require('dgram')
   , createBlock2    = require('./helpers').createBlock2
   , getOption       = require('./helpers').getOption
 
+function handleEnding(request, message) {
+  if (message.toString() !== 'end') {
+    request.server._sendError(message, request.rsinfo)
+  }
+}
+
+function parseRequest(request, next) {
+  try {
+    request.packet = parse(request.raw)
+    next(null)
+  } catch (err) {
+    next(new Buffer('Unable to parse packet'))
+  }
+}
+
+function handleServerRequest(request, next) {
+  try {
+    request.server._handle(request.packet, request.rsinfo)
+    next('end')
+  } catch (err) {
+    next(new Buffer(err.message))
+  }
+}
+
+function proxyRequest(request, next) {
+  for (var i = 0; i < request.packet.options.length; i++) {
+    if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
+      request.proxy = request.packet.options[i].value.toString()
+    }
+  }
+
+  if (request.proxy) {
+    if (request.packet.token.length === 0) {
+      request.packet.token = crypto.randomBytes(8);
+
+    }
+    request.server._sendProxied(request.packet, request.proxy)
+    request.server._proxiedRequests[request.packet.token.toString('hex')] = request
+    next('end')
+  } else {
+    next()
+  }
+}
+
+function handleProxyResponse(request, next) {
+  var originalProxiedRequest = request.server._proxiedRequests[request.packet.token.toString('hex')]
+  if ( originalProxiedRequest ) {
+    request.server._sendReverseProxied(request.packet, originalProxiedRequest.rsinfo)
+    delete request.server._proxiedRequests[request.packet.token.toString('hex')]
+    next('end')
+  } else {
+    next()
+  }
+}
+
 function CoAPServer(options, listener) {
   if (!(this instanceof CoAPServer)) {
     return new CoAPServer(options)
@@ -39,6 +94,17 @@ function CoAPServer(options, listener) {
 
   this._options = options
   this._proxiedRequests = {}
+
+  this._middlewares = [
+    parseRequest
+  ]
+
+  if (options.proxy) {
+    this._middlewares.push(proxyRequest)
+    this._middlewares.push(handleProxyResponse)
+  }
+
+  this._middlewares.push(handleServerRequest)
 
   // We use an LRU cache for the responses to avoid
   // DDOS problems.
@@ -90,73 +156,20 @@ CoAPServer.prototype._sendReverseProxied = function(packet, rsinfo) {
 }
 
 function handleRequest(server) {
-  function handleEnding(request, message) {
-    if (message.toString() !== 'end') {
-      server._sendError(message, request.rsinfo)
-    }
-  }
-
-  function parseRequest(request, next) {
-    try {
-      request.packet = parse(request.raw)
-      next(null)
-    } catch (err) {
-      next(new Buffer('Unable to parse packet'))
-    }
-  }
-
-  function handleServerRequest(request, next) {
-    try {
-      server._handle(request.packet, request.rsinfo)
-      next('end')
-    } catch (err) {
-      next(new Buffer(err.message))
-    }
-  }
-
-  function proxyRequest(request, next) {
-    for (var i = 0; i < request.packet.options.length; i++) {
-      if (request.packet.options[i].name.toLowerCase() === 'proxy-uri') {
-        request.proxy = request.packet.options[i].value.toString()
-      }
-    }
-
-    if (request.proxy) {
-      if (request.packet.token.length === 0) {
-        request.packet.token = crypto.randomBytes(8);
-
-      }
-      server._sendProxied(request.packet, request.proxy)
-      server._proxiedRequests[request.packet.token.toString('hex')] = request
-      next('end')
-    } else {
-      next()
-    }
-  }
-
-  function handleProxyResponse(request, next) {
-    var originalProxiedRequest = server._proxiedRequests[request.packet.token.toString('hex')]
-    if ( originalProxiedRequest ) {
-      server._sendReverseProxied(request.packet, originalProxiedRequest.rsinfo)
-      delete server._proxiedRequests[request.packet.token.toString('hex')]
-      next('end')
-    } else {
-      next()
-    }
-  }
 
   return function (msg, rsinfo) {
     var request = {
         raw: msg,
-        rsinfo: rsinfo
+        rsinfo: rsinfo,
+        server: server
       }
+      , activeMiddlewares = []
 
-    async.series([
-      async.apply(parseRequest, request),
-      async.apply(proxyRequest, request),
-      async.apply(handleProxyResponse, request),
-      async.apply(handleServerRequest, request)
-    ], async.apply(handleEnding, request))
+    for (var i = 0; i < server._middlewares.length; i++) {
+      activeMiddlewares.push(async.apply(server._middlewares[i], request))
+    }
+
+    async.series(activeMiddlewares, async.apply(handleEnding, request))
   }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,7 @@ function handleEnding(request, message, results) {
   }
 }
 
-function CoAPServer(options, listener, errorListener) {
+function CoAPServer(options, listener) {
   if (!(this instanceof CoAPServer)) {
     return new CoAPServer(options)
   }
@@ -215,7 +215,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   else if (packet.ack || packet.reset)
     return // nothing to do, ignoring silently
 
-  request = new IncomingMessage(packet)
+  request = new IncomingMessage(packet, rsinfo)
 
   if (request.headers['Observe'] === 0) {
     Message = ObserveStream

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sinon": "~1.7.3"
   },
   "dependencies": {
+    "async": "0.9.0",
     "bl": "~0.9.0",
     "coap-packet": "~0.1.12",
     "lru-cache": "~2.5.0",

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -88,4 +88,23 @@ describe('proxy', function() {
       }]
     }))
   })
+
+  it('should return the target response to the original requestor', function(done) {
+    send(generate({
+      options: [{
+        name: 'Proxy-Uri'
+        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+      }]
+    }))
+
+    target.on('request', function(req, res) {
+      res.end('The response')
+    })
+
+    client.on('message', function(msg) {
+      var package = parse(msg)
+      expect(package.payload.toString()).to.eql('The response')
+      done()
+    })
+  })
 })

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2013-2015 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
+var coap      = require('../')
+  , parse     = require('coap-packet').parse
+  , generate  = require('coap-packet').generate
+  , dgram     = require('dgram')
+  , bl        = require('bl')
+  , request   = coap.request
+  , tk        = require('timekeeper')
+  , sinon     = require('sinon')
+  , params    = require('../lib/parameters')
+  , async     = require('async')
+
+describe('proxy', function() {
+  var server
+    , port
+    , clientPort
+    , client
+    , target
+    , targetPort
+    , clock
+
+  beforeEach(function(done) {
+    clock = sinon.useFakeTimers()
+    port = nextPort()
+    server = coap.createServer()
+    server.listen(port, function() {
+      clientPort = nextPort()
+      client = dgram.createSocket('udp4')
+      targetPort = nextPort()
+      target = coap.createServer()
+
+      client.bind(clientPort, function() {
+        target.listen(targetPort, done)
+      })
+    })
+  })
+
+  afterEach(function() {
+    clock.restore()
+    client.close()
+    server.close()
+    target.close()
+    tk.reset()
+  })
+
+  function send(message) {
+    client.send(message, 0, message.length, port, '127.0.0.1')
+  }
+
+  function fastForward(increase, max) {
+    clock.tick(increase)
+    if (increase < max)
+      setImmediate(fastForward.bind(null, increase, max - increase))
+  }
+
+  it('should resend the message to its destination specified in the Proxy-Uri option', function(done) {
+    send(generate({
+      options: [{
+        name: 'Proxy-Uri'
+        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+      }]
+    }))
+
+    target.on('request', function(req, res) {
+      done()
+    })
+  })
+
+  it('should not process the request as a standard server request', function(done) {
+    target.on('request', function(req, res) {
+      done()
+    })
+
+    server.on('request', function(req, res) {
+    })
+
+    send(generate({
+      options: [{
+        name: 'Proxy-Uri'
+        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+      }]
+    }))
+  })
+})

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -29,7 +29,9 @@ describe('proxy', function() {
   beforeEach(function(done) {
     clock = sinon.useFakeTimers()
     port = nextPort()
-    server = coap.createServer()
+    server = coap.createServer({
+      proxy: true
+    })
     server.listen(port, function() {
       clientPort = nextPort()
       client = dgram.createSocket('udp4')

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -147,7 +147,7 @@ describe('proxy', function() {
   })
 
   describe('with a proxied request with a wrong destination', function() {
-    it('should forward the request to the URI specified in proxyUri ', function(done) {
+    it('should return an error to the caller', function(done) {
       var request = coap.request({
         host: 'localhost',
         port: port,

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -109,4 +109,39 @@ describe('proxy', function() {
       done()
     })
   })
+
+  describe('with a proxied request initiated by an agent', function() {
+    it('should forward the request to the URI specified in proxyUri ', function(done) {
+      var request = coap.request({
+        host: 'localhost',
+        port: port,
+        proxyUri: 'coap://localhost:' + targetPort,
+        query: 'a=b'
+      })
+
+      target.on('request', function(req, res) {
+        done()
+      })
+
+      request.end()
+    })
+    it('should forward the response to the request back to the agent', function(done) {
+      var request = coap.request({
+        host: 'localhost',
+        port: port,
+        proxyUri: 'coap://localhost:' + targetPort,
+        query: 'a=b'
+      })
+
+      target.on('request', function(req, res) {
+        res.end()
+      })
+
+      request.on('response', function() {
+        done()
+      })
+
+      request.end()
+    })
+  })
 })

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -165,7 +165,7 @@ describe('proxy', function() {
       request
           .on('response', function(res) {
             expect(res.code).to.eql('5.00');
-            expect(res.payload.toString()).to.eql('getaddrinfo ENOTFOUND');
+            expect(res.payload.toString()).to.contain('ENOTFOUND');
             done()
           })
           .end()

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -134,14 +134,41 @@ describe('proxy', function() {
       })
 
       target.on('request', function(req, res) {
-        res.end()
+        res.end('This is the response')
       })
 
-      request.on('response', function() {
+      request.on('response', function(res) {
+        expect(res.payload.toString()).to.eql('This is the response');
         done()
       })
 
       request.end()
+    })
+  })
+
+  describe('with a proxied request with a wrong destination', function() {
+    it('should forward the request to the URI specified in proxyUri ', function(done) {
+      var request = coap.request({
+        host: 'localhost',
+        port: port,
+        proxyUri: 'coap://unexistentCOAPUri:7968',
+        query: 'a=b'
+      })
+
+      target.on('request', function(req, res) {
+        console.log('should not get here')
+      })
+
+      server.on('error', function(req, res) {
+      })
+
+      request
+          .on('response', function(res) {
+            expect(res.code).to.eql('5.00');
+            expect(res.payload.toString()).to.eql('getaddrinfo ENOTFOUND');
+            done()
+          })
+          .end()
     })
   })
 })


### PR DESCRIPTION
Adds two features to the library:
* Add the `proxy` option to the server creation, so the server will behave like a COAP Proxy: if a request arrives containing the Proxy-Uri Option, instead of treating it like a normal request, it is forwarded to the destination indicated in the Option, removing the Proxy-Uri option from the package.
* Add the `proxyUri` option to the request options, so it can be directly indicated in the request creation (just adds the Proxy-Uri option to the final request).

In order to implement the server option, an important refactor in the request handler was done. I extracted the request handler function to a top-level function, and decomposed the process into a `parseRequest` and a `handleServerRequest` function. This functions were composed as a concatentation of middlewares with the signature `function(request, next)` being the `request` parameter a data object shared among all the middlewares processing a request and the `next()` function a callback to handle the pass to the next middleware. If the `next()` function is executed with a non-zero argument, the request processing stops and the final request processor is executed. If the parameter to the function was the string `end` the request is considered to have been processed correctly and no further action is done. Otherwise, the parameter is considered an error description and a `5.00` error is returned to the client. The list of middlewares for a server is stored in the `_middlewares` internal attribute of the server.

For the proxy features, two other middlewares were added: 
* `proxyRequest`: handles incoming requests containing the `Proxy-Uri` option. It removes the option and resend the request to the destination.
* `handleProxyResponse`: handles responses to proxied requests, using an internal `_proxiedRequests` object, matching the incoming requests using the `token` parameter of the request (for proxied requests, if no token is provided a new 8-byte length token is generated).