### PR TITLE
Fix server functionality in proxies

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -74,7 +74,7 @@ function handleProxyResponse(request, next) {
     delete request.server._proxiedRequests[request.packet.token.toString('hex')]
     next(null)
   } else {
-    next(new Error('missing request'))
+    next()
   }
 }
 

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -170,4 +170,30 @@ describe('proxy', function() {
           .end()
     })
   })
+
+  describe('with a non-proxied request', function() {
+    it('should call the handler as usual', function(done) {
+      var request = coap.request({
+        host: 'localhost',
+        port: port,
+        query: 'a=b'
+      })
+
+      target.on('request', function(req, res) {
+        console.log('should not get here')
+      })
+
+      server.on('request', function(req, res) {
+        res.end('Standard response')
+      })
+
+      request
+          .on('response', function(res) {
+            expect(res.payload.toString()).to.contain('Standard response');
+            done()
+          })
+          .end()
+    })
+  })
+
 })


### PR DESCRIPTION
With the last changes (the introduction of "fastseries"), the standard server functionality for servers with the proxy feature activated was broken, i.e: if a server is created with the `proxy` option, and a request is sent without the `proxyUri` option, the usual handler should be called, but, with the last modifications, a `missing request` error is received instead. This PR address that case.