### PR TITLE
Fix request error leak

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -314,7 +314,10 @@ Agent.prototype.request = function request(url) {
     that._msgInFlight++
   })
 
-  req.sender.on('timeout', that.abort.bind(that, req))
+  req.sender.on('timeout', function (err) {
+    req.emit('timeout', err)
+    that.abort(req)
+  })
 
   req.sender.on('sent', function() {
     that._msgInFlight--

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -314,6 +314,8 @@ Agent.prototype.request = function request(url) {
     that._msgInFlight++
   })
 
+  req.sender.on('timeout', that.abort.bind(that, req))
+
   req.sender.on('sent', function() {
     that._msgInFlight--
     if (that._closing && that._msgInFlight === 0) {
@@ -332,6 +334,15 @@ Agent.prototype.request = function request(url) {
 
   return req
 }
+
+Agent.prototype.abort = function (req) {
+  req.sender.removeAllListeners()
+  req.sender.reset()
+  this._cleanUp()
+  delete this._msgIdToReq[req._packet.messageId]
+  delete this._tkToReq[req._packet.token.readUInt32BE(0)]
+}
+
 
 function urlPropertyToPacketOption(url, req, property, option, separator) {
   if (url[property])

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -61,6 +61,7 @@ RetrySend.prototype.send = function(message, avoidBackoff) {
       var err  = new Error('No reply in ' + parameters.exchangeLifetime + 's')
       err.retransmitTimeout = parameters.exchangeLifetime;
       that.emit('error', err)
+      that.emit('timeout', err)
     }, parameters.exchangeLifetime * 1000)
 }
 

--- a/test/request.js
+++ b/test/request.js
@@ -614,6 +614,20 @@ describe('request', function() {
       fastForward(1000, 247 * 1000)
     })
 
+    it('should timeout after ~247 seconds', function(done) {
+      var req = doReq()
+
+      req.on('error', function() {})
+
+      req.on('timeout', function(err) {
+        expect(err).to.have.property('message', 'No reply in 247s')
+        expect(err).to.have.property('retransmitTimeout', 247)
+        done()
+      })
+
+      fastForward(1000, 247 * 1000)
+    })
+
     it('should retry four times before erroring', function(done) {
       var req = doReq()
         , messages = 0


### PR DESCRIPTION
I have added a 'timeout' event at RetrySend, and it is captured by the Agent that cleans up the request and avoids keeping a reference to a request that never will be completed