### PR TITLE
Check token integrity in reponses

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -217,7 +217,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
   else if (block2) {
     delete that._tkToReq[req._packet.token.readUInt32BE(0)]
   }
-  else if (!req.url.observe)
+  else if (!req.url.observe && packet.token.length > 0)
     // it is not, so delete the token
     delete that._tkToReq[packet.token.readUInt32BE(0)]
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -155,6 +155,9 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
       return
     }
+  } else if (packet.code != '0.00' && (req._packet.token.length != packet.token.length || req._packet.token.compare(packet.token) != 0)) {
+    // The tokens don't match, ignore the message since it is a malformed response
+    return
   }
 
   if (!packet.confirmable)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -24,6 +24,7 @@ var bl              = require('bl')
   , getOption       = require('./helpers').getOption
   , maxToken        = Math.pow(2, 32)
   , maxMessageId    = Math.pow(2, 16)
+  , pf              = require('./polyfill')
 
 function Agent(opts) {
   if (!(this instanceof Agent))
@@ -155,7 +156,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
       return
     }
-  } else if (packet.code != '0.00' && (req._packet.token.length != packet.token.length || req._packet.token.compare(packet.token) != 0)) {
+  } else if (packet.code != '0.00' && (req._packet.token.length != packet.token.length || pf.compareBuffers(req._packet.token, packet.token) != 0)) {
     // The tokens don't match, ignore the message since it is a malformed response
     return
   }

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,11 +1,11 @@
-if (!Buffer.prototype.compare) {
-  Buffer.prototype.compare = function (buf) {
-    if (this.length != buf.length) return -1
-
-    for (var i = 0; i < this.length; i++) {
-      if (this[i] != buf[i]) return -1
+exports.compareBuffers = function (buf1, buf2) {
+  if (Buffer.compare)
+    return Buffer.compare(buf1, buf2)
+  else {
+    if (buf1.length != buf2.length) return -1
+    for (var i = 0; i < buf1.length; i++) {
+      if (buf1[i] != buf2[i]) return -1
     }
-
     return 0
   }
 }

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,0 +1,11 @@
+if (!Buffer.prototype.compare) {
+  Buffer.prototype.compare = function (buf) {
+    if (this.length != buf.length) return -1
+
+    for (var i = 0; i < this.length; i++) {
+      if (this[i] != buf[i]) return -1
+    }
+
+    return 0
+  }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,8 @@
  * See the included LICENSE file for more details.
  */
 
+require('./polyfill')
+
 var dgram           = require('dgram')
   , net             = require('net')
   , util            = require('util')

--- a/test/request.js
+++ b/test/request.js
@@ -19,13 +19,13 @@ describe('request', function() {
     , server2
     , port
 
-  beforeEach(function(done) {
+  beforeEach(function (done) {
     port = nextPort()
     server = dgram.createSocket('udp4')
     server.bind(port, done)
   })
 
-  afterEach(function() {
+  afterEach(function () {
     server.close()
 
     if (server2)
@@ -37,17 +37,17 @@ describe('request', function() {
   function ackBack(msg, rsinfo) {
     var packet = parse(msg)
       , toSend = generate({
-                     messageId: packet.messageId
-                   , ack: true
-                   , code: '0.00'
-                 })
+        messageId: packet.messageId
+        , ack: true
+        , code: '0.00'
+      })
     server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
   }
 
-  it('should return a pipeable stream', function(done) {
+  it('should return a pipeable stream', function (done) {
     var req = request('coap://localhost:' + port)
       , stream = bl()
-    
+
     stream.append('hello world')
 
     req.on('finish', done)
@@ -55,65 +55,65 @@ describe('request', function() {
     stream.pipe(req)
   })
 
-  it('should send the data to the server', function(done) {
+  it('should send the data to the server', function (done) {
     var req = request('coap://localhost:' + port)
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
       expect(parse(msg).payload.toString()).to.eql('hello world')
       done()
     })
   })
 
-  it('should send a confirmable message by default', function(done) {
+  it('should send a confirmable message by default', function (done) {
     var req = request('coap://localhost:' + port)
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
       expect(parse(msg).confirmable).to.be.true
       done()
     })
   })
 
-  it('should emit the errors in the req', function(done) {
+  it('should emit the errors in the req', function (done) {
     var req = request('coap://aaa.eee:' + 1234)
     req.end(new Buffer('hello world'))
 
-    req.on('error', function() {
+    req.on('error', function () {
       done()
     })
   })
 
-  it('should error if the message is too big', function(done) {
+  it('should error if the message is too big', function (done) {
     var req = request('coap://localhost:' + port)
 
-    req.on('error', function() {
+    req.on('error', function () {
       done()
     })
 
     req.end(new Buffer(1280))
   })
 
-  it('should imply a default port', function(done) {
+  it('should imply a default port', function (done) {
     server2 = dgram.createSocket('udp4')
 
-    server2.bind(5683, function() {
+    server2.bind(5683, function () {
       request('coap://localhost').end()
     })
 
-    server2.on('message', function(msg, rsinfo) {
+    server2.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
       done()
     })
   })
 
-  it('should send the path to the server', function(done) {
+  it('should send the path to the server', function (done) {
     var req = request('coap://localhost:' + port + '/hello')
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
@@ -123,12 +123,12 @@ describe('request', function() {
       done()
     })
   })
-  
-  it('should send a longer path to the server', function(done) {
+
+  it('should send a longer path to the server', function (done) {
     var req = request('coap://localhost:' + port + '/hello/world')
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
@@ -140,16 +140,16 @@ describe('request', function() {
     })
   })
 
-  it('should accept an object instead of a string', function(done) {
+  it('should accept an object instead of a string', function (done) {
     var req = request({
-        hostname: 'localhost'
+      hostname: 'localhost'
       , port: port
       , pathname: '/hello/world'
     })
 
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
@@ -161,11 +161,11 @@ describe('request', function() {
     })
   })
 
-  it('should send a query string to the server', function(done) {
+  it('should send a query string to the server', function (done) {
     var req = request('coap://localhost:' + port + '?a=b&c=d')
     req.end(new Buffer('hello world'))
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
@@ -177,13 +177,13 @@ describe('request', function() {
     })
   })
 
-  it('should accept a method parameter', function(done) {
+  it('should accept a method parameter', function (done) {
     request({
-        port: port
+      port: port
       , method: 'POST'
     }).end()
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
@@ -192,26 +192,26 @@ describe('request', function() {
     })
   })
 
-  it('should emit a response with a piggyback CON message', function(done) {
+  it('should emit a response with a piggyback CON message', function (done) {
     var req = request({
-        port: port
+      port: port
       , confirmable: true
     })
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       var packet = parse(msg)
         , toSend = generate({
-                       messageId: packet.messageId
-                     , token: packet.token
-                     , payload: new Buffer('42')
-                     , ack: true
-                     , code: '2.00'
-                   })
+          messageId: packet.messageId
+          , token: packet.token
+          , payload: new Buffer('42')
+          , ack: true
+          , code: '2.00'
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
 
-    req.on('response', function(res) {
-      res.pipe(bl(function(err, data) {
+    req.on('response', function (res) {
+      res.pipe(bl(function (err, data) {
         expect(data).to.eql(new Buffer('42'))
         done()
       }))
@@ -220,25 +220,25 @@ describe('request', function() {
     req.end()
   })
 
-  it('should emit a response with a delayed CON message', function(done) {
+  it('should emit a response with a delayed CON message', function (done) {
     var req = request({
-        port: port
+      port: port
       , confirmable: true
     })
 
-    server.once('message', function(msg, rsinfo) {
+    server.once('message', function (msg, rsinfo) {
       var packet = parse(msg)
         , toSend = generate({
-                       messageId: packet.messageId
-                     , token: packet.token
-                     , payload: new Buffer('')
-                     , ack: true
-                     , code: '0.00'
-                   })
+          messageId: packet.messageId
+          , token: packet.token
+          , payload: new Buffer('')
+          , ack: true
+          , code: '0.00'
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
 
       toSend = generate({
-          token: packet.token
+        token: packet.token
         , payload: new Buffer('42')
         , confirmable: true
         , code: '2.00'
@@ -246,8 +246,8 @@ describe('request', function() {
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
 
-    req.on('response', function(res) {
-      res.pipe(bl(function(err, data) {
+    req.on('response', function (res) {
+      res.pipe(bl(function (err, data) {
         expect(data).to.eql(new Buffer('42'))
         done()
       }))
@@ -257,23 +257,23 @@ describe('request', function() {
   })
 
 
-  it('should send an ACK back after receiving a CON response', function(done) {
+  it('should send an ACK back after receiving a CON response', function (done) {
     var req = request({
-        port: port
+      port: port
       , confirmable: true
     })
 
-    server.once('message', function(msg, rsinfo) {
+    server.once('message', function (msg, rsinfo) {
       var packet = parse(msg)
         , toSend = generate({
-                       messageId: packet.messageId
-                     , ack: true
-                     , code: '0.00'
-                   })
+          messageId: packet.messageId
+          , ack: true
+          , code: '0.00'
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
 
       toSend = generate({
-          token: packet.token
+        token: packet.token
         , payload: new Buffer('42')
         , confirmable: true
         , code: '2.00'
@@ -281,7 +281,7 @@ describe('request', function() {
 
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
 
-      server.once('message', function(msg, rsinfo) {
+      server.once('message', function (msg, rsinfo) {
         packet = parse(msg)
         expect(packet.code).to.eql('0.00')
         expect(packet.ack).to.be.true
@@ -293,45 +293,45 @@ describe('request', function() {
     req.end()
   })
 
-  it('should not emit a response with an ack', function(done) {
+  it('should not emit a response with an ack', function (done) {
     var req = request({
-        port: port
+      port: port
       , confirmable: true
     })
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
-      setTimeout(function() {
+      setTimeout(function () {
         done()
       }, 20)
     })
 
-    req.on('response', function(res) {
+    req.on('response', function (res) {
       done(new Error('Unexpected response'))
     })
 
     req.end()
   })
 
-  it('should emit a response with a NON message', function(done) {
+  it('should emit a response with a NON message', function (done) {
     var req = request({
-        port: port
+      port: port
       , confirmable: false
     })
 
-    server.on('message', function(msg, rsinfo) {
+    server.on('message', function (msg, rsinfo) {
       var packet = parse(msg)
         , toSend = generate({
-                       messageId: packet.messageId
-                     , token: packet.token
-                     , payload: new Buffer('42')
-                     , code: '2.00'
-                   })
+          messageId: packet.messageId
+          , token: packet.token
+          , payload: new Buffer('42')
+          , code: '2.00'
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
 
-    req.on('response', function(res) {
-      res.pipe(bl(function(err, data) {
+    req.on('response', function (res) {
+      res.pipe(bl(function (err, data) {
         expect(data).to.eql(new Buffer('42'))
         done()
       }))
@@ -340,79 +340,79 @@ describe('request', function() {
     req.end()
   })
 
-  it('should allow to add an option', function(done) {
+  it('should allow to add an option', function (done) {
     var req = request({
-                port: port
-              })
+        port: port
+      })
       , buf = new Buffer(3)
-    
+
     req.setOption('ETag', buf)
     req.end()
 
-    server.on('message', function(msg) {
+    server.on('message', function (msg) {
       expect(parse(msg).options[0].name).to.eql('ETag')
       expect(parse(msg).options[0].value).to.eql(buf)
       done()
     })
   })
 
-  it('should overwrite the option', function(done) {
+  it('should overwrite the option', function (done) {
     var req = request({
-                port: port
-              })
+        port: port
+      })
       , buf = new Buffer(3)
-    
+
     req.setOption('ETag', new Buffer(3))
     req.setOption('ETag', buf)
     req.end()
 
-    server.on('message', function(msg) {
+    server.on('message', function (msg) {
       expect(parse(msg).options[0].value).to.eql(buf)
       done()
     })
   })
 
-  it('should alias setOption to setHeader', function(done) {
+  it('should alias setOption to setHeader', function (done) {
     var req = request({
-                port: port
-              })
+        port: port
+      })
       , buf = new Buffer(3)
-    
+
     req.setHeader('ETag', buf)
     req.end()
 
-    server.on('message', function(msg) {
+    server.on('message', function (msg) {
       expect(parse(msg).options[0].value).to.eql(buf)
       done()
     })
   })
 
-  it('should set multiple options', function(done) {
+  it('should set multiple options', function (done) {
     var req = request({
-                port: port
-              })
+        port: port
+      })
       , buf1 = new Buffer(3)
       , buf2 = new Buffer(3)
-    
+
     req.setOption('433', [buf1, buf2])
     req.end()
 
-    server.on('message', function(msg) {
+    server.on('message', function (msg) {
       expect(parse(msg).options[0].value).to.eql(buf1)
       expect(parse(msg).options[1].value).to.eql(buf2)
       done()
     })
   })
 
-  it('should alias the \'Content-Format\' option to \'Content-Type\'', function(done) {
+  it('should alias the \'Content-Format\' option to \'Content-Type\'', function (done) {
     var req = request({
-                port: port
-              })
-    
+      port: port
+    })
+
     req.setOption('Content-Type', new Buffer([0]))
     req.end()
 
-    server.on('message', function(msg) {
+    server.on('message', function (msg) {
       expect(parse(msg).options[0].name).to.eql('Content-Format')
       expect(parse(msg).options[0].value).to.eql(new Buffer([0]))
       done()
@@ -420,7 +420,7 @@ describe('request', function() {
   })
 
   var formatsString = {
-      'text/plain': new Buffer([0])
+    'text/plain': new Buffer([0])
     , 'application/link-format': new Buffer([40])
     , 'application/xml': new Buffer([41])
     , 'application/octet-stream': new Buffer([42])
@@ -428,17 +428,17 @@ describe('request', function() {
     , 'application/json': new Buffer([50])
   }
 
-  describe('with the \'Content-Format\' header in the outgoing message', function() {
+  describe('with the \'Content-Format\' header in the outgoing message', function () {
     function buildTest(format, value) {
-      it('should parse ' + format, function(done) {
+      it('should parse ' + format, function (done) {
         var req = request({
-                    port: port
-                  })
-        
+          port: port
+        })
+
         req.setOption('Content-Format', format)
         req.end()
 
-        server.on('message', function(msg) {
+        server.on('message', function (msg) {
           expect(parse(msg).options[0].value).to.eql(value)
           done()
         })
@@ -450,17 +450,17 @@ describe('request', function() {
     }
   })
 
-  describe('with the \'Accept\' header in the outgoing message', function() {
+  describe('with the \'Accept\' header in the outgoing message', function () {
     function buildTest(format, value) {
-      it('should parse ' + format, function(done) {
+      it('should parse ' + format, function (done) {
         var req = request({
-                    port: port
-                  })
-        
+          port: port
+        })
+
         req.setHeader('Accept', format)
         req.end()
 
-        server.on('message', function(msg) {
+        server.on('message', function (msg) {
           expect(parse(msg).options[0].value).to.eql(value)
           done()
         })
@@ -472,31 +472,31 @@ describe('request', function() {
     }
   })
 
-  describe('with the \'Content-Format\' in the response', function() {
+  describe('with the \'Content-Format\' in the response', function () {
     function buildResponse(value) {
-      return function(msg, rsinfo) {
-        var packet  = parse(msg)
-          , toSend  = generate({
-                          messageId: packet.messageId
-                        , token: packet.token
-                        , options: [{
-                              name: 'Content-Format'
-                            , value: value
-                          }]
-                     })
+      return function (msg, rsinfo) {
+        var packet = parse(msg)
+          , toSend = generate({
+            messageId: packet.messageId
+            , token: packet.token
+            , options: [{
+              name: 'Content-Format'
+              , value: value
+            }]
+          })
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
       }
     }
 
     function buildTest(format, value) {
-      it('should parse ' + format, function(done) {
+      it('should parse ' + format, function (done) {
         var req = request({
           port: port
         })
 
         server.on('message', buildResponse(value))
 
-        req.on('response', function(res) {
+        req.on('response', function (res) {
           expect(res.options[0].value).to.eql(format)
           done()
         })
@@ -504,14 +504,14 @@ describe('request', function() {
         req.end()
       })
 
-      it('should include ' + format + ' in the headers', function(done) {
+      it('should include ' + format + ' in the headers', function (done) {
         var req = request({
           port: port
         })
 
         server.on('message', buildResponse(value))
 
-        req.on('response', function(res) {
+        req.on('response', function (res) {
           expect(res.headers['Content-Format']).to.eql(format)
           expect(res.headers['Content-Type']).to.eql(format)
           done()
@@ -526,25 +526,25 @@ describe('request', function() {
     }
   })
 
-  it('should include \'ETag\' in the response headers', function(done) {
+  it('should include \'ETag\' in the response headers', function (done) {
     var req = request({
       port: port
     })
 
-    server.on('message', function(msg, rsinfo) {
-      var packet  = parse(msg)
-        , toSend  = generate({
-                        messageId: packet.messageId
-                      , token: packet.token
-                      , options: [{
-                            name: 'ETag'
-                          , value: new Buffer('abcdefgh')
-                        }]
-                    })
+    server.on('message', function (msg, rsinfo) {
+      var packet = parse(msg)
+        , toSend = generate({
+          messageId: packet.messageId
+          , token: packet.token
+          , options: [{
+            name: 'ETag'
+            , value: new Buffer('abcdefgh')
+          }]
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
 
-    req.on('response', function(res) {
+    req.on('response', function (res) {
       expect(res.headers).to.have.property('ETag', 'abcdefgh')
       done()
     })
@@ -552,22 +552,22 @@ describe('request', function() {
     req.end()
   })
 
-  it('should include original and destination socket information in the response', function(done) {
+  it('should include original and destination socket information in the response', function (done) {
     var req = request({
       port: port
     })
 
-    server.on('message', function(msg, rsinfo) {
-      var packet  = parse(msg)
-          , toSend  = generate({
-            messageId: packet.messageId
-            , token: packet.token
-            , options: []
-          })
+    server.on('message', function (msg, rsinfo) {
+      var packet = parse(msg)
+        , toSend = generate({
+          messageId: packet.messageId
+          , token: packet.token
+          , options: []
+        })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
 
-    req.on('response', function(res) {
+    req.on('response', function (res) {
       expect(res).to.have.property('rsinfo')
       expect(res).to.have.property('outSocket')
       expect(res.outSocket).to.have.property('address')
@@ -578,20 +578,20 @@ describe('request', function() {
     req.end()
   })
 
-  describe('non-confirmable retries', function() {
+  describe('non-confirmable retries', function () {
     var clock
 
-    beforeEach(function() {
+    beforeEach(function () {
       clock = sinon.useFakeTimers()
     })
 
-    afterEach(function() {
+    afterEach(function () {
       clock.restore()
     })
 
     function doReq() {
       return request({
-          port: port
+        port: port
         , confirmable: false
       }).end()
     }
@@ -602,10 +602,10 @@ describe('request', function() {
         setImmediate(fastForward.bind(null, increase, max - increase))
     }
 
-    it('should error after ~247 seconds', function(done) {
+    it('should error after ~247 seconds', function (done) {
       var req = doReq()
 
-      req.on('error', function(err) {
+      req.on('error', function (err) {
         expect(err).to.have.property('message', 'No reply in 247s')
         expect(err).to.have.property('retransmitTimeout', 247)
         done()
@@ -614,12 +614,13 @@ describe('request', function() {
       fastForward(1000, 247 * 1000)
     })
 
-    it('should timeout after ~247 seconds', function(done) {
+    it('should timeout after ~247 seconds', function (done) {
       var req = doReq()
 
-      req.on('error', function() {})
+      req.on('error', function () {
+      })
 
-      req.on('timeout', function(err) {
+      req.on('timeout', function (err) {
         expect(err).to.have.property('message', 'No reply in 247s')
         expect(err).to.have.property('retransmitTimeout', 247)
         done()
@@ -628,15 +629,15 @@ describe('request', function() {
       fastForward(1000, 247 * 1000)
     })
 
-    it('should retry four times before erroring', function(done) {
+    it('should retry four times before erroring', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         messages++
       })
 
-      req.on('error', function(err) {
+      req.on('error', function (err) {
         // original one plus 4 retries
         expect(messages).to.eql(5)
         done()
@@ -645,15 +646,15 @@ describe('request', function() {
       fastForward(100, 247 * 1000)
     })
 
-    it('should retry four times before 45s', function(done) {
+    it('should retry four times before 45s', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         messages++
       })
 
-      setTimeout(function() {
+      setTimeout(function () {
         // original one plus 4 retries
         expect(messages).to.eql(5)
         done()
@@ -662,25 +663,25 @@ describe('request', function() {
       fastForward(100, 45 * 1000)
     })
 
-    it('should stop retrying if it receives a message', function(done) {
+    it('should stop retrying if it receives a message', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg, rsinfo) {
+      server.on('message', function (msg, rsinfo) {
         messages++
-        var packet  = parse(msg)
-          , toSend  = generate({
-                          messageId: packet.messageId
-                        , token: packet.token
-                        , code: '2.00'
-                        , ack: true
-                        , payload: new Buffer(5)
-                      })
-        
+        var packet = parse(msg)
+          , toSend = generate({
+            messageId: packet.messageId
+            , token: packet.token
+            , code: '2.00'
+            , ack: true
+            , payload: new Buffer(5)
+          })
+
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
       })
 
-      setTimeout(function() {
+      setTimeout(function () {
         expect(messages).to.eql(1)
         done()
       }, 45 * 1000)
@@ -689,20 +690,20 @@ describe('request', function() {
     })
   })
 
-  describe('confirmable retries', function() {
+  describe('confirmable retries', function () {
     var clock
 
-    beforeEach(function() {
+    beforeEach(function () {
       clock = sinon.useFakeTimers()
     })
 
-    afterEach(function() {
+    afterEach(function () {
       clock.restore()
     })
 
     function doReq() {
       return request({
-          port: port
+        port: port
         , confirmable: true
       }).end()
     }
@@ -713,10 +714,10 @@ describe('request', function() {
         setImmediate(fastForward.bind(null, increase, max - increase))
     }
 
-    it('should error after ~247 seconds', function(done) {
+    it('should error after ~247 seconds', function (done) {
       var req = doReq()
 
-      req.on('error', function(err) {
+      req.on('error', function (err) {
         expect(err).to.have.property('message', 'No reply in 247s')
         done()
       })
@@ -724,15 +725,15 @@ describe('request', function() {
       fastForward(1000, 247 * 1000)
     })
 
-    it('should retry four times before erroring', function(done) {
+    it('should retry four times before erroring', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         messages++
       })
 
-      req.on('error', function(err) {
+      req.on('error', function (err) {
         // original one plus 4 retries
         expect(messages).to.eql(5)
         done()
@@ -741,11 +742,11 @@ describe('request', function() {
       fastForward(100, 247 * 1000)
     })
 
-    it('should retry with the same message id', function(done) {
+    it('should retry with the same message id', function (done) {
       var req = doReq()
         , messageId
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         var packet = parse(msg)
 
         if (!messageId)
@@ -754,22 +755,22 @@ describe('request', function() {
         expect(packet.messageId).to.eql(messageId)
       })
 
-      req.on('error', function(err) {
+      req.on('error', function (err) {
         done()
       })
 
       fastForward(100, 247 * 1000)
     })
 
-    it('should retry four times before 45s', function(done) {
+    it('should retry four times before 45s', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         messages++
       })
 
-      setTimeout(function() {
+      setTimeout(function () {
         // original one plus 4 retries
         expect(messages).to.eql(5)
         done()
@@ -778,23 +779,23 @@ describe('request', function() {
       fastForward(100, 45 * 1000)
     })
 
-    it('should stop retrying if it receives an ack', function(done) {
+    it('should stop retrying if it receives an ack', function (done) {
       var req = doReq()
         , messages = 0
 
-      server.on('message', function(msg, rsinfo) {
+      server.on('message', function (msg, rsinfo) {
         messages++
-        var packet  = parse(msg)
-          , toSend  = generate({
-                          messageId: packet.messageId
-                        , code: '0.00'
-                        , ack: true
-                      })
-        
+        var packet = parse(msg)
+          , toSend = generate({
+            messageId: packet.messageId
+            , code: '0.00'
+            , ack: true
+          })
+
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
       })
 
-      setTimeout(function() {
+      setTimeout(function () {
         expect(messages).to.eql(1)
         done()
       }, 45 * 1000)
@@ -803,41 +804,41 @@ describe('request', function() {
     })
   })
 
-  describe('observe', function() {
+  describe('observe', function () {
 
     function doObserve() {
-      server.on('message', function(msg, rsinfo) {
+      server.on('message', function (msg, rsinfo) {
         var packet = parse(msg)
 
         if (packet.ack)
           return
-        
+
         ssend(rsinfo, {
-            messageId: packet.messageId
+          messageId: packet.messageId
           , token: packet.token
           , payload: new Buffer('42')
           , ack: true
           , options: [{
-                name: 'Observe'
-              , value: new Buffer([1])
-            }]
+            name: 'Observe'
+            , value: new Buffer([1])
+          }]
           , code: '2.05'
         })
 
         ssend(rsinfo, {
-            token: packet.token
+          token: packet.token
           , payload: new Buffer('24')
           , confirmable: true
           , options: [{
-                name: 'Observe'
-              , value: new Buffer([2])
-            }]
+            name: 'Observe'
+            , value: new Buffer([2])
+          }]
           , code: '2.05'
         })
       })
 
       return request({
-          port: port
+        port: port
         , observe: true
       }).end()
     }
@@ -847,39 +848,39 @@ describe('request', function() {
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     }
 
-    it('should ack the update', function(done) {
+    it('should ack the update', function (done) {
 
       var req = doObserve()
 
-      server.on('message', function(msg) {
+      server.on('message', function (msg) {
         if (parse(msg).ack)
           done()
       })
     })
 
-    it('should emit any more data after close', function(done) {
+    it('should emit any more data after close', function (done) {
 
       var req = doObserve()
 
-      req.on('response', function(res) {
-        res.once('data', function(data) {
+      req.on('response', function (res) {
+        res.once('data', function (data) {
           expect(data.toString()).to.eql('42')
           res.close()
           done()
 
-          res.on('data', function(data) {
+          res.on('data', function (data) {
             done(new Error('this should never happen'))
           })
         })
       })
     })
 
-    it('should send origin and destination socket data along with the response', function(done) {
+    it('should send origin and destination socket data along with the response', function (done) {
 
       var req = doObserve()
 
-      req.on('response', function(res) {
-        res.once('data', function(data) {
+      req.on('response', function (res) {
+        res.once('data', function (data) {
           expect(res).to.have.property('rsinfo')
           expect(res).to.have.property('outSocket')
           expect(res.outSocket).to.have.property('address')
@@ -890,35 +891,111 @@ describe('request', function() {
       })
     })
 
-    it('should emit any more data after close', function(done) {
+    it('should emit any more data after close', function (done) {
 
       var req = doObserve()
 
-      req.on('response', function(res) {
-        res.once('data', function(data) {
+      req.on('response', function (res) {
+        res.once('data', function (data) {
           expect(data.toString()).to.eql('42')
           res.close()
           done()
 
-          res.on('data', function(data) {
+          res.on('data', function (data) {
             done(new Error('this should never happen'))
           })
         })
       })
     })
 
-    it('should send an empty Observe option', function(done) {
+    it('should send an empty Observe option', function (done) {
       var req = request({
-          port: port
+        port: port
         , observe: true
       }).end()
 
-      server.on('message', function(msg, rsinfo) {
+      server.on('message', function (msg, rsinfo) {
         var packet = parse(msg)
         expect(packet.options[0].name).to.eql('Observe')
         expect(packet.options[0].value).to.eql(new Buffer(0))
         done()
       })
     })
+  })
+
+  describe('token', function () {
+    var clock
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers()
+    })
+
+    afterEach(function () {
+      clock.restore()
+    })
+
+    function fastForward(increase, max) {
+      clock.tick(increase)
+      if (increase < max)
+        setImmediate(fastForward.bind(null, increase, max - increase))
+    }
+
+
+    it('should timeout if the response token size doesn\'t match the request\'s', function (done) {
+      var req = request({
+        port: port
+      })
+
+      server.on('message', function (msg, rsinfo) {
+        var packet = parse(msg)
+          , toSend = generate({
+            messageId: packet.messageId
+            , token: new Buffer(2)
+            , options: []
+          })
+        server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
+      })
+
+      req.on('error', function () {})
+
+      req.on('timeout', function () {
+        done()
+      })
+
+      req.end()
+
+
+      fastForward(1000, 247 * 1000)
+
+    })
+
+    it('should timeout if the response token content doesn\'t match the request\'s', function (done) {
+      var req = request({
+        port: port
+      })
+
+      server.on('message', function (msg, rsinfo) {
+        var packet = parse(msg)
+          , toSend = generate({
+            messageId: packet.messageId
+            , token: new Buffer(4)
+            , options: []
+          })
+        server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
+      })
+
+      req.on('error', function () {})
+
+      req.on('timeout', function () {
+        done()
+      })
+
+      req.end()
+
+
+      fastForward(1000, 247 * 1000)
+    })
+
+
   })
 })


### PR DESCRIPTION
Added a guard to check that the token in the response is the same that the one in the request, except for 0.00 messages. Right now the behavior is to ignore messages with different tokens, so if no correct message arrives, a timeout will be emitted.