### PR TITLE
Fix crash when receiving duplicate CON responses

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -220,7 +220,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       return req.response.append(packet)
     } else {
       // TODO There is a previous response but is not an ObserveStream !
-      req.response = null
+      return
     }
 
   }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -214,9 +214,15 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
   }
 
   if (req.response) {
-    // it is an observe request
-    // and we are already streaming
-    return req.response.append(packet)
+    if (req.response.append) {
+      // it is an observe request
+      // and we are already streaming
+      return req.response.append(packet)
+    } else {
+      // TODO There is a previous response but is not an ObserveStream !
+      req.response = null
+    }
+
   }
   else if (block2) {
     delete that._tkToReq[req._packet.token.readUInt32BE(0)]


### PR DESCRIPTION
Fix crash when receiving duplicate CON responses. Right now the behavior when receiving a duplicate CON response is to ignore it and return.