### PR TITLE
normalize option names for proper aliasing; closes #71

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,6 +14,7 @@ var toBinary    = require('./option_converter').toBinary
       , '0.03': 'PUT'
       , '0.04': 'DELETE'
     }
+  , capitalize  = require('capitalize')
 
 module.exports.genAck = function(request) {
   return {
@@ -33,6 +34,9 @@ var optionAliases = {
 function setOption(name, values) {
   var i
 
+  name = capitalize.words(name)
+  name = optionAliases[name] || name
+
   this._packet.options = this._packet.options.filter(function(option) {
     return option.name !== name
   })
@@ -42,7 +46,7 @@ function setOption(name, values) {
 
   for (i = 0; i < values.length; i++) {
     this._packet.options.push({
-        name: optionAliases[name] || name
+        name: name
       , value: toBinary(name, values[i])
     })
   }

--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "pre-commit": "0.0.9",
     "chai": "~1.9.1",
-    "mocha": "~1.21.4",
-    "timekeeper": "0.0.4",
-    "sinon": "~1.7.3"
+    "mocha": "^2.2.5",
+    "pre-commit": "0.0.9",
+    "sinon": "~1.7.3",
+    "timekeeper": "0.0.4"
   },
   "dependencies": {
     "bl": "~0.9.0",
+    "capitalize": "^1.0.0",
     "coap-packet": "~0.1.12",
     "fastseries": "^1.1.0",
     "lru-cache": "~2.5.0",

--- a/test/request.js
+++ b/test/request.js
@@ -356,6 +356,23 @@ describe('request', function() {
     })
   })
 
+
+  it('should attempt to normalize option case', function (done) {
+    var req = request({
+        port: port
+      })
+      , buf = new Buffer(3)
+
+    req.setOption('content-type', buf)
+    req.end()
+
+    server.on('message', function (msg) {
+      expect(parse(msg).options[0].name).to.eql('Content-Format')
+      expect(parse(msg).options[0].value).to.eql(buf)
+      done()
+    })
+  })
+
   it('should overwrite the option', function (done) {
     var req = request({
         port: port


### PR DESCRIPTION
- use `capitalize` module
- add test

Instead of lowercasing everything, capitalize instead.

I'm gonna go ahead and send this PR anyway, because my wager is that the names are case-insensitive.  The alias(es) won't work without normalization anyway.

see #71 and coap-technology/coap-technology.github.io#9