### PR TITLE
guard against closing closed/never-opened socket

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -161,26 +161,29 @@ CoAPServer.prototype.listen = function(port, address, done) {
     address = null
   }
 
+  if (this._sock) {
+    if (done)
+      done(new Error('Already listening'))
+    else
+      throw new Error('Already listening')
+
+    return this
+  }
+
   if (address && net.isIPv6(address))
     this._options.type = 'udp6'
 
   if (!this._options.type)
     this._options.type = 'udp4'
 
-  if (this._sock && done)
-    done(new Error('Already listening'))
-  else if (this._sock)
-    throw new Error('Already listening')
-  else {
-    this._sock = dgram.createSocket(this._options.type, handleRequest(this))
-    this._sock.on('error', function(error) {
-      that.emit('error', error)
-    })
+  this._sock = dgram.createSocket(this._options.type, handleRequest(this))
+  this._sock.on('error', function(error) {
+    that.emit('error', error)
+  })
 
-    this._sock.bind(port, address || null, done || null)
-    this._port = port
-    this._address = address
-  }
+  this._sock.bind(port, address || null, done || null)
+  this._port = port
+  this._address = address
 
   return this
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -161,42 +161,40 @@ CoAPServer.prototype.listen = function(port, address, done) {
     address = null
   }
 
-  if (this._sock && done)
-    done(new Error('Already listening'))
-  else if (this._sock)
-    throw new Error('Already listening')
-
   if (address && net.isIPv6(address))
     this._options.type = 'udp6'
 
   if (!this._options.type)
     this._options.type = 'udp4'
 
-  this._sock = dgram.createSocket(this._options.type, handleRequest(this))
+  if (this._sock && done)
+    done(new Error('Already listening'))
+  else if (this._sock)
+    throw new Error('Already listening')
+  else {
+    this._sock = dgram.createSocket(this._options.type, handleRequest(this))
+    this._sock.on('error', function(error) {
+      that.emit('error', error)
+    })
 
-  this._sock.on('error', function(error) {
-    that.emit('error', error)
-  })
-
-  this._sock.bind(port, address || null, done || null)
-  this._port = port
-  this._address = address
+    this._sock.bind(port, address || null, done || null)
+    this._port = port
+    this._address = address
+  }
 
   return this
 }
 
 CoAPServer.prototype.close = function(done) {
-  if (this._sock) {
-    this._sock.close()
-  }
-
-  this._lru.reset()
-
   if (done) {
     setImmediate(done)
   }
 
-  this._sock = null
+  if (this._sock) {
+    this._sock.close()
+    this._lru.reset()
+    this._sock = null
+  }
 
   return this
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -186,7 +186,9 @@ CoAPServer.prototype.listen = function(port, address, done) {
 }
 
 CoAPServer.prototype.close = function(done) {
-  this._sock.close()
+  if (this._sock) {
+    this._sock.close()
+  }
 
   this._lru.reset()
 

--- a/test/server.js
+++ b/test/server.js
@@ -890,5 +890,20 @@ describe('server', function() {
         })
       })
     })
+
+    it('should only close once', function(done){
+      server.close(function(){
+        server.close(done)
+      })
+    })
+
+    it('should not overwrite existing socket', function(done){
+      var initial_sock = server._sock
+      server.listen(server._port+1, function(err){
+        expect(err.message).to.eql('Already listening')
+        expect(server._sock).to.eql(initial_sock)
+        done()
+      })
+    })
   })
 })

--- a/test/server.js
+++ b/test/server.js
@@ -241,6 +241,21 @@ describe('server', function() {
     })
   })
 
+  it('should only close once', function(done){
+    server.close(function(){
+      server.close(done)
+    })
+  })
+
+  it('should not overwrite existing socket', function(done){
+    var initial_sock = server._sock
+    server.listen(server._port+1, function(err){
+      expect(err.message).to.eql('Already listening')
+      expect(server._sock).to.eql(initial_sock)
+      done()
+    })
+  })
+
   var formatsString = {
       'text/plain': new Buffer([0])
     , 'application/link-format': new Buffer([40])
@@ -888,21 +903,6 @@ describe('server', function() {
 
           done()
         })
-      })
-    })
-
-    it('should only close once', function(done){
-      server.close(function(){
-        server.close(done)
-      })
-    })
-
-    it('should not overwrite existing socket', function(done){
-      var initial_sock = server._sock
-      server.listen(server._port+1, function(err){
-        expect(err.message).to.eql('Already listening')
-        expect(server._sock).to.eql(initial_sock)
-        done()
       })
     })
   })


### PR DESCRIPTION
Simple if-guard. Throwing an error probably not desirable, since when calling `close` we want it closed; if it already is closed then there's no error in the outcome, just an odd request.