### PR TITLE
normalize names, encoding information & writeHead; closes #71 and #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ for all the possible options.
 #### message.reset()
 Returns a Reset COAP Message to the sender. The RST message will appear as an empty message with code `0.00` and the
 reset flag set to `true` to the caller. This action ends the interaction with the caller.
+
+#### message.writeHead(code, headers)
+Functions somewhat like `http`'s `writeHead()` function.  If `code` is does not match the CoAP code mask of `#.##`, it is coerced into this mask.  `headers` is an object with keys being the header names, and values being the header values.   
 -------------------------------------------------------
 <a name="incoming"></a>
 ### IncomingMessage

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,6 +14,7 @@ var toBinary    = require('./option_converter').toBinary
       , '0.03': 'PUT'
       , '0.04': 'DELETE'
     }
+  , capitalize  = require('capitalize')
 
 module.exports.genAck = function(request) {
   return {
@@ -27,11 +28,15 @@ module.exports.genAck = function(request) {
 }
 
 var optionAliases = {
-  'Content-Type': 'Content-Format'
+  'Content-Type': 'Content-Format',
+  'Etag': 'ETag'
 }
 
 function setOption(name, values) {
   var i
+
+  name = capitalize.words(name)
+  name = optionAliases[name] || name
 
   this._packet.options = this._packet.options.filter(function(option) {
     return option.name !== name
@@ -42,7 +47,7 @@ function setOption(name, values) {
 
   for (i = 0; i < values.length; i++) {
     this._packet.options.push({
-        name: optionAliases[name] || name
+        name: name
       , value: toBinary(name, values[i])
     })
   }

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -77,8 +77,8 @@ registerFormat('application/octet-stream', 42)
 registerFormat('application/exi', 47)
 registerFormat('application/json', 50)
 
-var contentFormatToBinary = function(result) {
-  result = formatsString[result]
+var contentFormatToBinary = function(value) {
+  var result = formatsString[value.split(';')[0]]
   if (!result)
     throw new Error('Unknown Content-Format: ' + value)
 

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -99,4 +99,15 @@ OutgoingMessage.prototype.reset = function() {
   return this
 }
 
+OutgoingMessage.prototype.writeHead = function(code, headers) {
+  var packet = this._packet
+  var header
+  packet.code = String(code).replace(/(^\d[^.])/, '$1.')
+  for (header in headers) {
+    if (headers.hasOwnProperty(header)) {
+      this.setOption(header, headers[header])
+    }
+  }
+}
+
 module.exports = OutgoingMessage

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bl": "~0.9.0",
+    "capitalize": "^1.0.0",
     "coap-packet": "~0.1.12",
     "fastseries": "^1.1.0",
     "lru-cache": "~2.5.0",

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -208,6 +208,34 @@ describe('end-to-end', function() {
     })
   })
 
+  it('should allow encoding with \'Content-Format\'', function(done) {
+    var req = coap.request('coap://localhost:' + port)
+
+    req.setOption('Content-Format', 'application/json; charset=utf8')
+    req.end()
+
+    server.on('request', function(req) {
+      expect(req.options[0].name).to.equal('Content-Format')
+      expect(req.options[0].value).to.equal('application/json')
+      done()
+    })
+  })
+
+  it('should provide a writeHead() method', function(done) {
+    var req = coap.request('coap://localhost:' + port)
+    req.end();
+    req.on('response', function(res) {
+      expect(res.headers['Content-Format']).to.equal('application/json')
+      done()
+    })
+
+    server.on('request', function(req, res) {
+      res.writeHead(200, {'Content-Format': 'application/json'})
+      res.write(JSON.stringify({}))
+      res.end()
+    })
+  })
+
   it('should set and parse \'Location-Path\'', function(done) {
     var req = coap.request({
         port: port

--- a/test/request.js
+++ b/test/request.js
@@ -356,6 +356,22 @@ describe('request', function() {
     })
   })
 
+  it('should attempt to normalize option case', function (done) {
+    var req = request({
+        port: port
+      })
+      , buf = new Buffer(3)
+
+    req.setOption('content-type', buf)
+    req.end()
+
+    server.on('message', function (msg) {
+      expect(parse(msg).options[0].name).to.eql('Content-Format')
+      expect(parse(msg).options[0].value).to.eql(buf)
+      done()
+    })
+  })
+
   it('should overwrite the option', function (done) {
     var req = request({
         port: port


### PR DESCRIPTION
- Add `capitalize` package as dependency
- To normalize option names, capitalize each word of the name.  "content-format" becomes "Content-Format", etc.  special case for "ETag", which was added to the alias map.
- Fixed an undefined variable in `option_converter`'s `contentFormatToBinary()`
- Added `OutgoingMessage.prototype.writeHead()` as to provide more compatibility with the `http` module
- Encoding information can be sent in *any* `Content-Format` value, but it is discarded.  From what I can gather from the RFC7252 and other RFCs I read, we only seem to be *required* to accept the encoding information with `text/plain`; support any other format would be optional, but since sending a type such as `application/json; charset=utf-8` is so common, we may as well
- Updated `README.md` with `writeHead()` info.