### PR TITLE
CRITICAL: fix request hangs when using blockwise transfers in unreliable networks

### DIFF
--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -9,6 +9,7 @@
 var parameters      = require('./parameters')
   , util            = require('util')
   , EventEmitter    = require('events').EventEmitter
+  , parse           = require('coap-packet').parse
 
 function RetrySend(sock, port, host) {
   if (!(this instanceof RetrySend))
@@ -23,6 +24,7 @@ function RetrySend(sock, port, host) {
   this._host  = host
 
   this._sendAttemp = 0
+  this._lastMessageId = -1
   this._currentTime = parameters.ackTimeout * (1 + (parameters.ackRandomFactor - 1) * Math.random()) * 1000
 
   this._bOff  = function() {
@@ -43,6 +45,12 @@ RetrySend.prototype._send = function(avoidBackoff) {
                       that.emit('error', err)
                     }
                   })
+
+  var messageId = parse(this._message).messageId
+  if (messageId != this._lastMessageId) {
+    this._lastMessageId = messageId
+    this._sendAttemp = 0
+  }
 
   if (!avoidBackoff && ++this._sendAttemp <= parameters.maxRetransmit)
     this._bOffTimer = setTimeout(this._bOff, this._currentTime)


### PR DESCRIPTION
Hi,

I've fixed a critical bug when packets are lost in the middle of a blockwise transfer. There was a unique counter for send attemps for ALL messageIds. Since this counter was incremented every new message, once you send more that 5 messages, the attempt counter is over the limit and no retries will be performed.

I've added a field in RetrySend to keep track of the messageId, and reset counter and currentTime when messageID changes.

I've not added any test since this is just a bugfix and it does not introduce new functionality. Besides, I don't know how to mock a blockwise transfer ...