### PR TITLE
Allow more than one multicast server to bind on same port and address

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -180,7 +180,7 @@ CoAPServer.prototype.listen = function(port, address, done) {
   if (!this._options.type)
     this._options.type = 'udp4'
 
-  this._sock = dgram.createSocket(this._options.type, handleRequest(this))
+  this._sock = dgram.createSocket({type: this._options.type, reuseAddr : true}, handleRequest(this))
   this._sock.on('error', function(error) {
     that.emit('error', error)
   })


### PR DESCRIPTION
I was trying to run the 'multicast_client_server' example, but was throwing 'EADDRINUSE' bind error.
I ended founding the explanation on this thread: https://github.com/mdns-js/node-mdns-js/issues/31
Just one change on 'lib/server.js' and the example worked. So i made this little pull request.

Hope that helps. 

P.s.: running more than one server in different process also work
Note: i tested on node v0.12.7