### PR TITLE
Fix undefined var problem in isObserve()

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -51,7 +51,7 @@ function proxyRequest(request, next) {
 }
 
 function isObserve(packet) {
-  packet.options.reduce(or, false);
+  return packet.options.reduce(or, false);
 }
 
 function handleProxyResponse(request, next) {

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -51,7 +51,7 @@ function proxyRequest(request, next) {
 }
 
 function isObserve(packet) {
-  request.packet.options.reduce(or, false);
+  packet.options.reduce(or, false);
 }
 
 function handleProxyResponse(request, next) {

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -112,7 +112,7 @@ describe('proxy', function() {
   it('should resend notifications in an observe connection', function(done) {
     var counter = 0,
         req;
-
+    clock.restore()
     req = sendObservation()
 
     req.on('response', function(res) {

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -144,6 +144,12 @@ describe('proxy', function() {
   })
 
   it('should return the target response to the original requestor', function(done) {
+    var counter = 0;
+    clock.restore()
+    setTimeout( function() {      
+      done();
+    }, 300 );
+    
     send(generate({
       options: [{
         name: 'Proxy-Uri'
@@ -152,13 +158,14 @@ describe('proxy', function() {
     }))
 
     target.on('request', function(req, res) {
+      counter++;
+      expect(counter).to.eql(1);   
       res.end('The response')
     })
 
     client.on('message', function(msg) {
       var package = parse(msg)
       expect(package.payload.toString()).to.eql('The response')
-      done()
     })
   })
 


### PR DESCRIPTION
When I tried to use the coap proxy server, I got a curious error.  I created a proxy and target servers in separate processes, based on the example proxy code, and then used the coap-cli module to construct a message to the target through the proxy (i.e., I added the `proxyUri` option).  The message and response worked, but shortly after the client received the response, the proxy and the target got locked into an endless loop of debug like this: 

`Target receives [request is not defined] in port [8976] from port [6780].`

I tracked the problem down to isObserve(), where it appears `request` is being used instead of `packet`, and which is also not even testing anything because it doesn't return a value.  

All of the unit tests pass in spite of this.  Apparently, that's because it takes too much time for the error to percolate up, and I guess none of the tests check for unexpected requests anyway.

I could use some advice on the test I added.  I had to disable the sinon fake timers to get it to pass (otherwise, it would hang forever), which is probably bad form.  I'm sure there is a way to use them and make it work, but I'm not familiar enough with them to know how.
