### PR TITLE
Customize CoAP parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ first ten come from different ports.
   * <a href="#agent"><code>coap.<b>Agent</b></code></a>
   * <a href="#globalAgent"><code>coap.<b>globalAgent</b></code></a>
   * <a href="#globalAgentIPv6"><code>coap.<b>globalAgentIPv6</b></code></a>
+  * <a href="#updateTiming"><code>coap.<b>updateTiming</b></code></a>
+  * <a href="#defaultTiming"><code>coap.<b>defaultTiming</b></code></a>
 
 -------------------------------------------------------
 <a name="request"></a>
@@ -217,7 +219,7 @@ The constructor can be given an optional options object, containing one of the f
 * `proxy`: indicates that the server should behave like a proxy for incoming requests containing the `Proxy-Uri` header.
   An example of how the proxy feature works, refer to the example in the `/examples` folder. Defaults to `false`.
 * `multicastAddress`: Optional. Use this in order to force server to listen on multicast address
-* `multicastInterface`: Optional. Use this in order to force server to listen on multicast interface. This is only applicable 
+* `multicastInterface`: Optional. Use this in order to force server to listen on multicast interface. This is only applicable
   if `multicastAddress` is set. If absent, server will try to listen `multicastAddress` on all available interfaces
 * `piggybackReplyMs`: set the number of milliseconds to wait for a
   biggyback response. Default 50.
@@ -226,7 +228,7 @@ The constructor can be given an optional options object, containing one of the f
 
 `function (request, response) { }`
 
-Emitted each time there is a request. 
+Emitted each time there is a request.
 `request` is an instance of <a
 href='#incoming'><code>IncomingMessage</code></a> and `response` is
 an instance of <a
@@ -418,7 +420,7 @@ Information about the socket used for the communication (address and port).
 <a name="observewrite"></a>
 ### ObserveWriteStream
 
-An `ObserveWriteStream` object is 
+An `ObserveWriteStream` object is
 emitted by the `coap.createServer` `'response'` event as a response
 object.
 It may be used to set response status, headers and stream changing data
@@ -502,6 +504,30 @@ The default [`Agent`](#agent) for IPv4.
 ### coap.globalAgentIPv6
 
 The default [`Agent`](#agent) for IPv6.
+
+-------------------------------------------------------
+<a name="updateTiming"></a>
+### coap.updateTiming
+
+You can update the CoAP timing settings, take a look at the examples:
+
+```js
+var coapTiming = {
+  ackTimeout:0.25,
+  ackRandomFactor: 1.0,
+  maxRetransmit: 3,
+  probingRate: 1,
+  maxLatency: 2,
+  piggybackReplyMs: 10
+};
+coap.updateTiming(coapTiming);
+```
+
+-------------------------------------------------------
+<a name="defaultTiming"></a>
+### coap.defaultTiming
+
+Reset the CoAP timings to the default values
 
 <a name="contributing"></a>
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -516,7 +516,6 @@ var coapTiming = {
   ackTimeout:0.25,
   ackRandomFactor: 1.0,
   maxRetransmit: 3,
-  probingRate: 1,
   maxLatency: 2,
   piggybackReplyMs: 10
 };

--- a/index.js
+++ b/index.js
@@ -48,3 +48,5 @@ module.exports.registerFormat = optionsConv.registerFormat
 module.exports.ignoreOption = optionsConv.ignoreOption
 
 module.exports.parameters = parameters
+module.exports.updateTiming = parameters.refreshTiming
+module.exports.defaultTiming = parameters.defaultTiming

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,55 +1,64 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
- *
- * node-coap is licensed under an MIT +no-false-attribs license.
- * All rights not explicitly granted in the MIT license are reserved.
- * See the included LICENSE file for more details.
- */
+* Copyright (c) 2013-2015 node-coap contributors.
+*
+* node-coap is licensed under an MIT +no-false-attribs license.
+* All rights not explicitly granted in the MIT license are reserved.
+* See the included LICENSE file for more details.
+*/
 
 // CoAP parameters
 var p = {
-    ackTimeout: 2 // seconds
+  ackTimeout: 2 // seconds
   , ackRandomFactor: 1.5
   , maxRetransmit: 4
-  , nstart: 1
-  , defaultLeisure: 5
   , probingRate: 1 // byte/seconds
 
   // MAX_LATENCY is the maximum time a datagram is expected to take
   // from the start of its transmission to the completion of its
   // reception.
   , maxLatency: 100 // seconds
-
   , piggybackReplyMs: 50
+  // default coap port
+  , coapPort: 5683
+  // default max packet size
+  , maxPacketSize: 1280
 }
+var defaultTiming = JSON.parse(JSON.stringify(p))
 
-// MAX_TRANSMIT_SPAN is the maximum time from the first transmission
-// of a Confirmable message to its last retransmission.
-p.maxTransmitSpan = p.ackTimeout * ((Math.pow(2, p.maxRetransmit)) - 1) * p.ackRandomFactor
+p.refreshTiming = function(values) {
+  for (var key in values){
+    if (p[key]) {
+      p[key] = values[key]
+    }
+  }
 
-// MAX_TRANSMIT_WAIT is the maximum time from the first transmission
-// of a Confirmable message to the time when the sender gives up on
-// receiving an acknowledgement or reset.
-p.maxTransmitWait = p.ackTimeout * (Math.pow(2, p.maxRetransmit + 1) - 1) * p.ackRandomFactor
+  // MAX_TRANSMIT_SPAN is the maximum time from the first transmission
+  // of a Confirmable message to its last retransmission.
+  p.maxTransmitSpan = p.ackTimeout * ((Math.pow(2, p.maxRetransmit)) - 1) * p.ackRandomFactor
+
+  // MAX_TRANSMIT_WAIT is the maximum time from the first transmission
+  // of a Confirmable message to the time when the sender gives up on
+  // receiving an acknowledgement or reset.
+  p.maxTransmitWait = p.ackTimeout * (Math.pow(2, p.maxRetransmit + 1) - 1) * p.ackRandomFactor
+
+  // PROCESSING_DELAY is the time a node takes to turn around a
+  // Confirmable message into an acknowledgement.
+  p.processingDelay = p.ackTimeout
+
+  // MAX_RTT is the maximum round-trip time
+  p.maxRTT = 2 * p.maxLatency + p.processingDelay
+
+  //  EXCHANGE_LIFETIME is the time from starting to send a Confirmable
+  //  message to the time when an acknowledgement is no longer expected,
+  //  i.e.  message layer information about the message exchange can be
+  //  purged
+  p.exchangeLifetime = p.maxTransmitSpan + p.maxRTT
+}
+p.refreshTiming()
 
 
-// PROCESSING_DELAY is the time a node takes to turn around a
-// Confirmable message into an acknowledgement.
-p.processingDelay = p.ackTimeout
-
-// MAX_RTT is the maximum round-trip time
-p.maxRTT = 2 * p.maxLatency + p.processingDelay
-
-//  EXCHANGE_LIFETIME is the time from starting to send a Confirmable
-//  message to the time when an acknowledgement is no longer expected,
-//  i.e.  message layer information about the message exchange can be
-//  purged
-p.exchangeLifetime = p.maxTransmitSpan + p.maxRTT
-
-// default port for CoAP
-p.coapPort = 5683
-
-// default max packet size
-p.maxPacketSize = 1280
+p.defaultTiming = function() {
+  p.refreshTiming(defaultTiming)
+}
 
 module.exports = p

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -11,7 +11,6 @@ var p = {
   ackTimeout: 2 // seconds
   , ackRandomFactor: 1.5
   , maxRetransmit: 4
-  , probingRate: 1 // byte/seconds
 
   // MAX_LATENCY is the maximum time a datagram is expected to take
   // from the start of its transmission to the completion of its

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -24,7 +24,6 @@ describe('Parameters', function() {
       ackTimeout: 1,
       ackRandomFactor: 2,
       maxRetransmit: 3,
-      probingRate: 4,
       maxLatency: 5,
       piggybackReplyMs: 6
     };

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,0 +1,50 @@
+var coap = require('../')
+var parameters = coap.parameters
+
+describe('Parameters', function() {
+
+  afterEach(function() {
+    parameters.defaultTiming()
+  })
+
+  it('should ignore empty parameter', function() {
+    //WHEN
+    coap.updateTiming();
+
+    // THEN
+    expect(parameters.maxRTT).to.eql(202)
+    expect(parameters.exchangeLifetime).to.eql(247)
+    expect(parameters.maxTransmitSpan).to.eql(45)
+    expect(parameters.maxTransmitWait).to.eql(93)
+  })
+
+  it('should verify custom timings', function() {
+    // GIVEN
+    var coapTiming = {
+      ackTimeout: 1,
+      ackRandomFactor: 2,
+      maxRetransmit: 3,
+      probingRate: 4,
+      maxLatency: 5,
+      piggybackReplyMs: 6
+    };
+
+    //WHEN
+    coap.updateTiming(coapTiming);
+
+    // THEN
+    expect(parameters.maxRTT).to.eql(11)
+    expect(parameters.exchangeLifetime).to.eql(25)
+    expect(parameters.maxTransmitSpan).to.eql(14)
+    expect(parameters.maxTransmitWait).to.eql(30)
+  })
+
+  it('should verify default timings', function() {
+    // THEN
+    expect(parameters.maxRTT).to.eql(202)
+    expect(parameters.exchangeLifetime).to.eql(247)
+    expect(parameters.maxTransmitSpan).to.eql(45)
+    expect(parameters.maxTransmitWait).to.eql(93)
+  })
+
+})


### PR DESCRIPTION
This pull requests adds the option to customize the coap timings, you can for example customize the maximal RTT for a coap package, redefine retires etc.

Note: I removed some unreferenced parameters:
- nstart
- defaultLeisure
- probingRate