### PR TITLE
Remove notice about blockwise not being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,11 +538,6 @@ __node-coap__ is an **OPEN Open Source Project**. This means that:
 
 See the [CONTRIBUTING.md](https://github.com/mcollina/node-coap/blob/master/CONTRIBUTING.md) file for more details.
 
-## Limitations
-
-The maximum packet size is 1280, as the
-[blockwise](http://datatracker.ietf.org/doc/draft-ietf-core-block/) is
-not supported yet.
 
 ## Contributors
 


### PR DESCRIPTION
It seems this is supported now (for the last 9 versions).