### PR TITLE
Accept EAI_AGAIN as DNS failure

### DIFF
--- a/test/proxy.js
+++ b/test/proxy.js
@@ -221,7 +221,7 @@ describe('proxy', function() {
       request
           .on('response', function(res) {
             expect(res.code).to.eql('5.00');
-            expect(res.payload.toString()).to.contain('ENOTFOUND');
+            expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/);
             done()
           })
           .end()


### PR DESCRIPTION
The error code apparently depends on some configuration. Adding this
one in order to have tests passing in my development environment.