### PR TITLE
Do not retry non-confirmable requests

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -316,7 +316,7 @@ Agent.prototype.request = function request(url) {
     that._msgIdToReq[packet.messageId] = req
     that._tkToReq[that._lastToken] = req
 
-    req.sender.send(buf)
+    req.sender.send(buf, !packet.confirmable)
   })
 
   req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host)

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -69,7 +69,8 @@ RetrySend.prototype.send = function(message, avoidBackoff) {
   this._timer = setTimeout(function() {
     var err  = new Error('No reply in ' + timeout + 's')
     err.retransmitTimeout = timeout;
-    that.emit('error', err)
+    if (!avoidBackoff)
+      that.emit('error', err)
     that.emit('timeout', err)
   }, timeout * 1000)
 }

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -60,17 +60,18 @@ RetrySend.prototype._send = function(avoidBackoff) {
 
 RetrySend.prototype.send = function(message, avoidBackoff) {
   var that = this
+    , timeout
 
   this._message = message
   this._send(avoidBackoff)
 
-  if (!avoidBackoff)
-    this._timer = setTimeout(function() {
-      var err  = new Error('No reply in ' + parameters.exchangeLifetime + 's')
-      err.retransmitTimeout = parameters.exchangeLifetime;
-      that.emit('error', err)
-      that.emit('timeout', err)
-    }, parameters.exchangeLifetime * 1000)
+  timeout = avoidBackoff ? parameters.maxRTT : parameters.exchangeLifetime
+  this._timer = setTimeout(function() {
+    var err  = new Error('No reply in ' + timeout + 's')
+    err.retransmitTimeout = timeout;
+    that.emit('error', err)
+    that.emit('timeout', err)
+  }, timeout * 1000)
 }
 
 RetrySend.prototype.reset = function() {

--- a/test/request.js
+++ b/test/request.js
@@ -657,18 +657,6 @@ describe('request', function() {
         setImmediate(fastForward.bind(null, increase, max - increase))
     }
 
-    it('should error after ~202 seconds', function (done) {
-      var req = doReq()
-
-      req.on('error', function (err) {
-        expect(err).to.have.property('message', 'No reply in 202s')
-        expect(err).to.have.property('retransmitTimeout', 202)
-        done()
-      })
-
-      fastForward(1000, 202*1000)
-    })
-
     it('should timeout after ~202 seconds', function (done) {
       var req = doReq()
 
@@ -684,7 +672,7 @@ describe('request', function() {
       fastForward(1000, 202 * 1000)
     })
 
-    it('should not retry before erroring', function (done) {
+    it('should not retry before timeout', function (done) {
       var req = doReq()
         , messages = 0
 
@@ -692,7 +680,7 @@ describe('request', function() {
         messages++
       })
 
-      req.on('error', function (err) {
+      req.on('timeout', function (err) {
         expect(messages).to.eql(1)
         done()
       })

--- a/test/request.js
+++ b/test/request.js
@@ -657,34 +657,34 @@ describe('request', function() {
         setImmediate(fastForward.bind(null, increase, max - increase))
     }
 
-    it('should error after ~247 seconds', function (done) {
+    it('should error after ~202 seconds', function (done) {
       var req = doReq()
 
       req.on('error', function (err) {
-        expect(err).to.have.property('message', 'No reply in 247s')
-        expect(err).to.have.property('retransmitTimeout', 247)
+        expect(err).to.have.property('message', 'No reply in 202s')
+        expect(err).to.have.property('retransmitTimeout', 202)
         done()
       })
 
-      fastForward(1000, 247 * 1000)
+      fastForward(1000, 202*1000)
     })
 
-    it('should timeout after ~247 seconds', function (done) {
+    it('should timeout after ~202 seconds', function (done) {
       var req = doReq()
 
       req.on('error', function () {
       })
 
       req.on('timeout', function (err) {
-        expect(err).to.have.property('message', 'No reply in 247s')
-        expect(err).to.have.property('retransmitTimeout', 247)
+        expect(err).to.have.property('message', 'No reply in 202s')
+        expect(err).to.have.property('retransmitTimeout', 202)
         done()
       })
 
-      fastForward(1000, 247 * 1000)
+      fastForward(1000, 202 * 1000)
     })
 
-    it('should retry four times before erroring', function (done) {
+    it('should not retry before erroring', function (done) {
       var req = doReq()
         , messages = 0
 
@@ -693,15 +693,14 @@ describe('request', function() {
       })
 
       req.on('error', function (err) {
-        // original one plus 4 retries
-        expect(messages).to.eql(5)
+        expect(messages).to.eql(1)
         done()
       })
 
       fastForward(100, 247 * 1000)
     })
 
-    it('should retry four times before 45s', function (done) {
+    it('should not retry before 45s', function (done) {
       var req = doReq()
         , messages = 0
 
@@ -710,8 +709,7 @@ describe('request', function() {
       })
 
       setTimeout(function () {
-        // original one plus 4 retries
-        expect(messages).to.eql(5)
+        expect(messages).to.eql(1)
         done()
       }, 45 * 1000)
 


### PR DESCRIPTION
I could not find an exact statement whether non-confirmable request CAN/SHOULD/MUST [NOT] be retried. But IMO it SHOULD be sent only once, especially for multicast requests. Also, tools like Californium send only one non-confirmable request, even if retry option is selected.