### PR TITLE
add new option for retrySend

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If it is an object:
   will be emitted for each received response. It's user's responsibility to set proper multicast `host` parameter
   in request configuration. Default `false`.
 - `multicastTimeout`: time to wait for multicast reponses in milliseconds. It is only applicable in case if `multicast` is `true`. Default `20000 ms`.
+- `retrySend`: overwrite the default maxRetransmit, useful when you want to use a custom retry count for a request
 
 
 `coap.request()` returns an instance of <a

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -333,7 +333,7 @@ Agent.prototype.request = function request(url) {
     req.sender.send(buf, !packet.confirmable)
   })
 
-  req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host)
+  req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host, url.retrySend)
 
   req.url = url
 

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -11,7 +11,7 @@ var parameters      = require('./parameters')
   , EventEmitter    = require('events').EventEmitter
   , parse           = require('coap-packet').parse
 
-function RetrySend(sock, port, host) {
+function RetrySend(sock, port, host, maxRetransmit) {
   if (!(this instanceof RetrySend))
     return new RetrySend(port, host)
 
@@ -23,6 +23,7 @@ function RetrySend(sock, port, host) {
 
   this._host  = host
 
+  this._maxRetransmit = maxRetransmit || parameters.maxRetransmit;
   this._sendAttemp = 0
   this._lastMessageId = -1
   this._currentTime = parameters.ackTimeout * (1 + (parameters.ackRandomFactor - 1) * Math.random()) * 1000
@@ -52,7 +53,7 @@ RetrySend.prototype._send = function(avoidBackoff) {
     this._sendAttemp = 0
   }
 
-  if (!avoidBackoff && ++this._sendAttemp <= parameters.maxRetransmit)
+  if (!avoidBackoff && ++this._sendAttemp <= this._maxRetransmit)
     this._bOffTimer = setTimeout(this._bOff, this._currentTime)
 
   this.emit('sending', this._message)

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -12,8 +12,9 @@ var parameters      = require('./parameters')
   , parse           = require('coap-packet').parse
 
 function RetrySend(sock, port, host, maxRetransmit) {
-  if (!(this instanceof RetrySend))
-    return new RetrySend(port, host)
+  if (!(this instanceof RetrySend)) {
+    return new RetrySend(sock, port, host, maxRetransmit)
+  }
 
   var that    = this
 
@@ -28,7 +29,7 @@ function RetrySend(sock, port, host, maxRetransmit) {
   this._lastMessageId = -1
   this._currentTime = parameters.ackTimeout * (1 + (parameters.ackRandomFactor - 1) * Math.random()) * 1000
 
-  this._bOff  = function() {
+  this._bOff = function() {
     that._currentTime = that._currentTime * 2
     that._send()
   }

--- a/test/retry_send.js
+++ b/test/retry_send.js
@@ -14,4 +14,14 @@ describe('RetrySend', function() {
     expect(result._maxRetransmit).to.eql(55)
   })
 
+  it('should use default retry count, using the retry_send factory method', function() {
+    var result = RetrySend({}, 1234, 'localhost')
+    expect(result._maxRetransmit).to.eql(parameters.maxRetransmit)
+  })
+
+  it('should use a custom retry count, using the retry_send factory method', function() {
+    var result = RetrySend({}, 1234, 'localhost', 55)
+    expect(result._maxRetransmit).to.eql(55)
+  })
+
 })

--- a/test/retry_send.js
+++ b/test/retry_send.js
@@ -1,0 +1,17 @@
+var coap = require('../')
+var parameters = coap.parameters
+var RetrySend = require('../lib/retry_send')
+
+describe('RetrySend', function() {
+
+  it('should use the default retry count', function() {
+    var result = new RetrySend({}, 1234, 'localhost')
+    expect(result._maxRetransmit).to.eql(parameters.maxRetransmit)
+  })
+
+  it('should use a custom retry count', function() {
+    var result = new RetrySend({}, 1234, 'localhost', 55)
+    expect(result._maxRetransmit).to.eql(55)
+  })
+
+})


### PR DESCRIPTION
Currently node-coap does not allows to set separate options for client and server. My use case: coap server should retransmit 3 times, but the other way around I want only one retransmit.

Thats why this PR, it allows to set a custom retry count for a new CoAP request.

Tests are missing, I just want to get some feedback first