### PR TITLE
Only set ETag for Block2 response if ETag has not been set manually

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -502,8 +502,13 @@ OutMessage.prototype.end= function(payload) {
     that.statusCode = '4.02'
     return OutgoingMessage.prototype.end.call(that)
   }
+
   this.setOption('Block2', block2)
-  this.setOption('ETag', _toETag(payload))
+
+  var hasETag = getOption(this._packet.options, 'ETag');
+  if (!hasETag) {
+    this.setOption('ETag', _toETag(payload))
+  }
 
   // cache it
   if (this._request.token && this._request.token.length > 0) {


### PR DESCRIPTION
Currently node-coap automatically sets ETag option for Block2 response and this overrides any manually set ETag value.

I've added a check to see if there's any ETag value set manually before overwriting them.