### PR TITLE
Add RST packet processing fixes

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -70,9 +70,6 @@ Agent.prototype._init = function initSock(socket) {
     try {
       packet = parse(msg)
     } catch(err) {
-      message = generate({ code: '5.00', payload: new Buffer('Unable to parse packet') })
-      that._sock.send(message, 0, message.length,
-                      rsinfo.port, rsinfo.address)
       return
     }
 
@@ -150,9 +147,8 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       req = this._tkToReq[packet.token.readUInt32BE(0)]
     }
 
-    if (packet.ack && !req) {
-      // nothing to do, somehow there was
-      // a duplicate ack
+    if ((packet.ack || packet.reset) && !req) {
+      // Nothing to do on unknown or duplicate ACK/RST packet
       return
     }
 
@@ -191,7 +187,8 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 
   req.sender.reset()
 
-  if (packet.code == '0.00')
+  // Drop empty messages (ACKs), but process RST
+  if (packet.code == '0.00' && !packet.reset)
     return
 
   var block2Buff = getOption(packet.options, 'Block2')

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -59,18 +59,18 @@ OutgoingMessage.prototype.end = function(a, b) {
   BufferList.prototype.end.call(this, a, b)
 
   var packet = this._packet
-    , message
     , that = this
 
   packet.code = toCode(this.code || this.statusCode)
   packet.payload = this
+
+  if (this._ackTimer)
+    clearTimeout(this._ackTimer)
+
   this._send(this, packet)
 
   // easy clean up after generating the packet
   delete this._packet.payload
-
-  if (this._ackTimer)
-    clearTimeout(this._ackTimer)
 
   return this
 }
@@ -79,21 +79,21 @@ OutgoingMessage.prototype.reset = function() {
   BufferList.prototype.end.call(this)
 
   var packet = this._packet
-    , message
     , that = this
 
   packet.code = '0.00'
   packet.payload = ''
   packet.reset = true;
   packet.ack = false
+  packet.token = ''
+
+  if (this._ackTimer)
+    clearTimeout(this._ackTimer)
 
   this._send(this, packet)
 
   // easy clean up after generating the packet
   delete this._packet.payload
-
-  if (this._ackTimer)
-    clearTimeout(this._ackTimer)
 
   return this
 }

--- a/test/server.js
+++ b/test/server.js
@@ -227,12 +227,14 @@ describe('server', function() {
 
   it('should include a reset() function in the response', function(done) {
     var buf = new Buffer(25)
-    send(generate({ payload: buf }))
+    var tok = new Buffer(4)
+    send(generate({ payload: buf, token: tok }))
     client.on('message', function(msg, rinfo) {
       var result = parse(msg)
       expect(result.code).to.eql('0.00')
       expect(result.reset).to.eql(true)
       expect(result.ack).to.eql(false)
+      expect(result.token.length).to.eql(0)
       expect(result.payload.length).to.eql(0)
       done()
     });


### PR DESCRIPTION
This PR fixes several issues when processing RST packets, including original issue #154:
* Server sends RST packet with token
* Server sends NON '5.00' "Empty message must be empty" after the RST
* Server sends ACK after the RST
* In rare occasions client may send a RST message in response to RST
* Request does not finish after receiving RST (cleanUp is not called, so the program just "hangs" without finishing)

Could anyone review the changes? @mcollina @neophob?

Also, I was unsure how should I handle a RST as a response - at first I did a separate req.on('reset') event, but then just slapped RST into response as it does not alter the API. Which do you guys think is better?