### PR TITLE
Fix without timeout error when using existing socket

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -110,7 +110,8 @@ Agent.prototype._cleanUp = function cleanUp() {
   if (--this._requests !== 0)
     return
 
-  this._closing = true
+  if (!this._opts.socket)
+    this._closing = true
 
   if (this._msgInFlight !== 0)
     return


### PR DESCRIPTION
I use an Agent with existing socket. It will call `agent._cleanUp()` to set `agent._closing` to be `true` as soon as it receive a response. Then `agent._doClose()` will be called and `req.sender._timer` will be cleared when I use the same Agent to send requests. Therefore, timeout error event will never be fired. I recognize that `agent._closing` should not be set to `true` when Agent using existing socket.