### PR TITLE
Allow url.observe to be a number

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -383,7 +383,9 @@ Agent.prototype.request = function request(url) {
     }, multicastTimeout)
   }
 
-  if (url.observe)
+  if (typeof (url.observe) === "number")
+    req.setOption('Observe', url.observe)
+  else if (url.observe)
     req.setOption('Observe', null)
   else
     req.on('response', this._cleanUp.bind(this))


### PR DESCRIPTION
RFC 7641 Section 2 defined that the Observe option may have an integer value:
   0 (register) adds the entry to the list, if not present;
   1 (deregister) removes the entry from the list, if present.

This commit allows the url.observe to be also a JS number object,
instead of just `true`, thereby adding support for observe deregistration.