### PR TITLE
Fix multicast tests

### DIFF
--- a/test/request.js
+++ b/test/request.js
@@ -1150,16 +1150,19 @@ describe('request', function() {
 
 
   describe('multicast', function () {
+    var MULTICAST_ADDR = '224.0.0.1'
 
     function doReq() {
       return request({
-        host: '224.0.0.1'
+        host: MULTICAST_ADDR
         , port: port
         , multicast: true
       }).end()
     }
 
     it('should be non-confirmable', function (done) {
+      server.addMembership(MULTICAST_ADDR)
+
       var req = doReq()
 
       server.on('message', function(msg, rsinfo) {
@@ -1170,6 +1173,8 @@ describe('request', function() {
     })
 
     it('should be responsed with the same token', function (done) {
+      server.addMembership(MULTICAST_ADDR)
+
       var req = doReq()
       , token
 

--- a/test/request.js
+++ b/test/request.js
@@ -1160,9 +1160,11 @@ describe('request', function() {
       }).end()
     }
 
-    it('should be non-confirmable', function (done) {
-      server.addMembership(MULTICAST_ADDR)
+    beforeEach(function() {
+      server.addMembership(MULTICAST_ADDR)      
+    });
 
+    it('should be non-confirmable', function (done) {
       var req = doReq()
 
       server.on('message', function(msg, rsinfo) {
@@ -1173,8 +1175,6 @@ describe('request', function() {
     })
 
     it('should be responsed with the same token', function (done) {
-      server.addMembership(MULTICAST_ADDR)
-
       var req = doReq()
       , token
 


### PR DESCRIPTION
Server wasn't bound to specific multicast address and that caused failing of two multicast tests.
Has been fixed by calling addMembership method of server with multicast address as an argument