### PR TITLE
Inherit ObserveWriteStream from OutgoingMessage as per API documentation

### DIFF
--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -8,12 +8,14 @@
  * See the included LICENSE file for more details.
  */
 
-var Writable = require('readable-stream').Writable
-  , util       = require('util')
-  , helpers    = require('./helpers')
+var Writable        = require('readable-stream').Writable
+  , util            = require('util')
+  , OutgoingMessage = require('./outgoing_message')
+  , helpers         = require('./helpers')
 
 function ObserveWriteStream(request, send) {
   Writable.call(this)
+  OutgoingMessage.call(this, request, send)
 
   this._packet = {
       token: request.token
@@ -39,6 +41,7 @@ function ObserveWriteStream(request, send) {
 }
 
 util.inherits(ObserveWriteStream, Writable)
+util.inherits(ObserveWriteStream, OutgoingMessage)
 helpers.addSetOption(ObserveWriteStream)
 
 ObserveWriteStream.prototype._write = function write(data, encoding, done) {


### PR DESCRIPTION
As [documentation for ObserveWriteStream](https://github.com/mcollina/node-coap#observewrite) says it implements the Writable Stream and OutgoingMessage interfaces, but in code there hasn't been any OutgoingMessage interface implementation (or inheritance in our case).
The issue created problem with `piggybackReplyMs `- this config property wasn't used for sending empty ACK in case of separate response ([RFC](https://tools.ietf.org/html/rfc7252#section-5.2.2)) so we needed to manually send piggybacked response to acknowledge client and then send second response with actually payload and client had to handle 2 responses every time