### PR TITLE
Implemented Block1 transfers. Fixed dgram socket being closed prematurely

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,13 @@ Since v0.7.0, this library supports blockwise transfers, you can trigger
 them by adding a `req.setOption('Block2', new Buffer([0x2]))` to the
 output of [request](#request).
 
+And since v?.?.?, this library supports rudimentry type 1 blockwise transfers, you can trigger
+them by adding a `req.setOption('Block1', new Buffer([0x2]))` to the
+options of [request](#request).
+
+(The hex value 0x2 specifies the size of the blocks to transfer with.
+Use values 0 to 6 for 16 to 1024 byte block sizes respectively.)
+
 See the
 [spec](http://tools.ietf.org/html/draft-ietf-core-coap-18#section-5.4)
 for all the possible options.

--- a/examples/blockwise_put.js
+++ b/examples/blockwise_put.js
@@ -1,0 +1,110 @@
+const coap = require('../')
+const url = require('url');
+const fs = require('fs');
+
+const bufferSize = 25000;
+const testBuffer = Buffer.alloc(bufferSize);
+const containedData = "This is a test buffer with a lot of nothing and a bit of something";
+testBuffer.fill('X', 'utf-8');
+testBuffer.write(containedData, 'utf-8');
+testBuffer.write(containedData, testBuffer.length-containedData.length, containedData.length, 'utf-8');
+
+/**
+ * Formula for chunk/block sizes is:
+ * ByteSize = 2^(chunkSize+4);
+ * Hence
+ *   chunkSize = 0  =>  ByteSize = 16
+ *   chunkSize = 6  =>  ByteSize = 1024
+ *   chunkSize = 7  =>  Reserved. Don't do it.
+ */
+
+/** 
+ * Tests the GET Block2 method transfer. Sends data in 1024 byte chunks
+*/
+function TestGet () {
+    coap.createServer(function (req, res) {
+        //Respond with the test buffer.
+        res.end(testBuffer);
+    }).listen(function () {
+        //GET Request resources /test with block transfer with 1024 byte size
+        var req = coap.request('/test');
+
+        req.setOption('Block2', new Buffer([0x6]));
+
+        req.on('response', function (res) {
+            console.log("Client Received " + res.payload.length + " bytes");
+            process.exit(0);
+        });
+
+        req.end();
+    });
+}
+/** 
+ * Tests the PUT Block1 method transfer. Sends data in 1024 byte chunks
+*/
+function TestPut () {
+    coap.createServer(function (req, res) {
+        console.log("Server Received " + req.payload.length + " bytes");
+        console.log(req.payload.slice(0, containedData.length).toString('utf-8'));
+        console.log(req.payload.slice(-containedData.length).toString('utf-8'));
+        console.log("Sending back pleasantries");
+        res.end("Congratulations!");
+        console.log("Sent back");
+    }).listen(function () {
+        var request = coap.request({
+            hostname: this.hostname,
+            port: this.port,
+            pathname: '/test',
+            method: 'PUT'
+        });
+        request.setOption('Block1', new Buffer([0x6]));
+
+        request.on('response', function (res) {
+            console.log("Client Received Response: " + res.payload.toString('utf-8'));
+            process.exit(0);
+        });
+        console.log("Sending large data from client...");
+        request.end(testBuffer);
+        console.log("Sent to server");
+    });
+}
+/** 
+ * Creates a CoAP server which listens for connections from outside.
+ * Start up an external CoAP client and try it out.
+*/
+function TestServer () {
+    coap.createServer(function (req, res) {
+        res.setOption('Block2', new Buffer([0x6]));
+        console.log("Sending Back Test Buffer");
+        res.end(testBuffer);
+        console.log("Sent Back");
+    }).listen();
+}
+
+/** 
+ * Connects to another end point located on this machine. Setup a coap server somewhere else and try it out.
+*/
+function TestClient () {
+    var request = coap.request({
+        hostname: "localhost",
+        port: 5683,
+        pathname: '/test',
+        method: 'PUT'
+    });
+    request.setOption('Block1', new Buffer([0]));
+
+    request.on('response', function (res) {
+        console.log("Client Received " + res.payload.length + " bytes in response");
+        process.exit(0);
+    });
+
+    console.log("Sending " + testBuffer.length + " bytes from client...");
+    request.end(testBuffer);
+    console.log("Sent to server");
+}
+//Choose yer poison
+
+TestPut();
+// TestGet();
+// TestServer();
+// TestClient();

--- a/examples/blockwise_put.js
+++ b/examples/blockwise_put.js
@@ -1,17 +1,17 @@
 const coap = require('../')
-const url = require('url');
-const fs = require('fs');
+const url = require('url')
+const fs = require('fs')
 
-const bufferSize = 25000;
-const testBuffer = Buffer.alloc(bufferSize);
-const containedData = "This is a test buffer with a lot of nothing and a bit of something";
-testBuffer.fill('X', 'utf-8');
-testBuffer.write(containedData, 'utf-8');
-testBuffer.write(containedData, testBuffer.length-containedData.length, containedData.length, 'utf-8');
+const bufferSize = 25000
+const testBuffer = Buffer.alloc(bufferSize)
+const containedData = "This is a test buffer with a lot of nothing and a bit of something"
+testBuffer.fill('X', 'utf-8')
+testBuffer.write(containedData, 'utf-8')
+testBuffer.write(containedData, testBuffer.length-containedData.length, containedData.length, 'utf-8')
 
 /**
  * Formula for chunk/block sizes is:
- * ByteSize = 2^(chunkSize+4);
+ * ByteSize = 2^(chunkSize+4)
  * Hence
  *   chunkSize = 0  =>  ByteSize = 16
  *   chunkSize = 6  =>  ByteSize = 1024
@@ -22,89 +22,89 @@ testBuffer.write(containedData, testBuffer.length-containedData.length, containe
  * Tests the GET Block2 method transfer. Sends data in 1024 byte chunks
 */
 function TestGet () {
-    coap.createServer(function (req, res) {
-        //Respond with the test buffer.
-        res.end(testBuffer);
-    }).listen(function () {
-        //GET Request resources /test with block transfer with 1024 byte size
-        var req = coap.request('/test');
+  coap.createServer(function (req, res) {
+    //Respond with the test buffer.
+    res.end(testBuffer)
+  }).listen(function () {
+    //GET Request resources /test with block transfer with 1024 byte size
+    var req = coap.request('/test')
 
-        req.setOption('Block2', new Buffer([0x6]));
+    req.setOption('Block2', new Buffer([0x6]))
 
-        req.on('response', function (res) {
-            console.log("Client Received " + res.payload.length + " bytes");
-            process.exit(0);
-        });
+    req.on('response', function (res) {
+      console.log("Client Received " + res.payload.length + " bytes")
+      process.exit(0)
+    })
 
-        req.end();
-    });
+    req.end()
+  })
 }
 /** 
  * Tests the PUT Block1 method transfer. Sends data in 1024 byte chunks
 */
 function TestPut () {
-    coap.createServer(function (req, res) {
-        console.log("Server Received " + req.payload.length + " bytes");
-        console.log(req.payload.slice(0, containedData.length).toString('utf-8'));
-        console.log(req.payload.slice(-containedData.length).toString('utf-8'));
-        console.log("Sending back pleasantries");
-        res.end("Congratulations!");
-        console.log("Sent back");
-    }).listen(function () {
-        var request = coap.request({
-            hostname: this.hostname,
-            port: this.port,
-            pathname: '/test',
-            method: 'PUT'
-        });
-        request.setOption('Block1', new Buffer([0x6]));
+  coap.createServer(function (req, res) {
+    console.log("Server Received " + req.payload.length + " bytes")
+    console.log(req.payload.slice(0, containedData.length).toString('utf-8'))
+    console.log(req.payload.slice(-containedData.length).toString('utf-8'))
+    console.log("Sending back pleasantries")
+    res.end("Congratulations!")
+    console.log("Sent back")
+  }).listen(function () {
+    var request = coap.request({
+      hostname: this.hostname,
+      port: this.port,
+      pathname: '/test',
+      method: 'PUT'
+    })
+    request.setOption('Block1', new Buffer([0x6]))
 
-        request.on('response', function (res) {
-            console.log("Client Received Response: " + res.payload.toString('utf-8'));
-            process.exit(0);
-        });
-        console.log("Sending large data from client...");
-        request.end(testBuffer);
-        console.log("Sent to server");
-    });
+    request.on('response', function (res) {
+      console.log("Client Received Response: " + res.payload.toString('utf-8'))
+      process.exit(0)
+    })
+    console.log("Sending large data from client...")
+    request.end(testBuffer)
+    console.log("Sent to server")
+  })
 }
 /** 
  * Creates a CoAP server which listens for connections from outside.
  * Start up an external CoAP client and try it out.
 */
 function TestServer () {
-    coap.createServer(function (req, res) {
-        res.setOption('Block2', new Buffer([0x6]));
-        console.log("Sending Back Test Buffer");
-        res.end(testBuffer);
-        console.log("Sent Back");
-    }).listen();
+  coap.createServer(function (req, res) {
+    res.setOption('Block2', new Buffer([0x6]))
+    console.log("Sending Back Test Buffer")
+    res.end(testBuffer)
+    console.log("Sent Back")
+  }).listen()
 }
 
 /** 
  * Connects to another end point located on this machine. Setup a coap server somewhere else and try it out.
 */
 function TestClient () {
-    var request = coap.request({
-        hostname: "localhost",
-        port: 5683,
-        pathname: '/test',
-        method: 'PUT'
-    });
-    request.setOption('Block1', new Buffer([0]));
+  var request = coap.request({
+    hostname: "localhost",
+    port: 5683,
+    pathname: '/test',
+    method: 'PUT'
+  })
+  request.setOption('Block1', new Buffer([0]))
 
-    request.on('response', function (res) {
-        console.log("Client Received " + res.payload.length + " bytes in response");
-        process.exit(0);
-    });
+  request.on('response', function (res) {
+    console.log("Client Received " + res.payload.length + " bytes in response")
+    process.exit(0)
+  })
 
-    console.log("Sending " + testBuffer.length + " bytes from client...");
-    request.end(testBuffer);
-    console.log("Sent to server");
+  console.log("Sending " + testBuffer.length + " bytes from client...")
+  request.end(testBuffer)
+  console.log("Sent to server")
 }
 //Choose yer poison
 
-TestPut();
-// TestGet();
-// TestServer();
-// TestClient();
+TestPut()
+// TestGet()
+// TestServer()
+// TestClient()

--- a/examples/blockwise_put.js
+++ b/examples/blockwise_put.js
@@ -44,12 +44,15 @@ function TestGet () {
 */
 function TestPut () {
   coap.createServer(function (req, res) {
-    console.log("Server Received " + req.payload.length + " bytes")
-    console.log(req.payload.slice(0, containedData.length).toString('utf-8'))
-    console.log(req.payload.slice(-containedData.length).toString('utf-8'))
-    console.log("Sending back pleasantries")
-    res.end("Congratulations!")
-    console.log("Sent back")
+    setTimeout(() => {
+      console.log("Server Received " + req.payload.length + " bytes")
+      console.log(req.payload.slice(0, containedData.length*2).toString('utf-8'))
+      console.log(req.payload.slice(-containedData.length).toString('utf-8'))
+      console.log("Sending back pleasantries")
+      res.statusCode = "2.04";
+      res.end("Congratulations!")
+      console.log("Sent back")
+    }, 500);
   }).listen(function () {
     var request = coap.request({
       hostname: this.hostname,
@@ -61,6 +64,7 @@ function TestPut () {
 
     request.on('response', function (res) {
       console.log("Client Received Response: " + res.payload.toString('utf-8'))
+      console.log("Client Received Response: " + res.code)
       process.exit(0)
     })
     console.log("Sending large data from client...")
@@ -74,10 +78,13 @@ function TestPut () {
 */
 function TestServer () {
   coap.createServer(function (req, res) {
-    res.setOption('Block2', new Buffer([0x6]))
-    console.log("Sending Back Test Buffer")
-    res.end(testBuffer)
-    console.log("Sent Back")
+    console.log("Got request. Waiting 500ms");
+    setTimeout(() => {
+        res.setOption('Block2', new Buffer([0x6]))
+        console.log("Sending Back Test Buffer")
+        res.end(testBuffer)
+        console.log("Sent Back")
+    }, 500);
   }).listen()
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -365,11 +365,11 @@ Agent.prototype.request = function request(url) {
     that._msgIdToReq[packet.messageId] = req
     that._tkToReq[that._lastToken] = req
 
-    var block1Buff = getOption(packet.options, 'Block1');
+    var block1Buff = getOption(packet.options, 'Block1')
     if(block1Buff) {
       // Setup for a segmented transmission
-      req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet);
-      req.segmentedSender.sendNext();
+      req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet)
+      req.segmentedSender.sendNext()
     } else {
       try {
         buf = generate(packet)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -335,6 +335,7 @@ Agent.prototype._nextMessageId = function nextToken() {
  */
 Agent.prototype.request = function request(url) {
   this._init()
+  this._closing = false;
 
   var req
     , response

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,6 +25,8 @@ var bl              = require('bl')
   , maxMessageId    = Math.pow(2, 16)
   , pf              = require('./polyfill')
   , hasDNSbug       = true
+  , SegmentedTransmission = require("./segmentation").SegmentedTransmission
+  , parseBlockOption = require("./block").parseBlockOption
 
 ;(function () {
   var major = parseInt(process.version.match(/^v([^.]+).*$/)[1])
@@ -66,7 +68,6 @@ Agent.prototype._init = function initSock(socket) {
     var packet
       , message
       , outSocket
-
     try {
       packet = parse(msg)
     } catch(err) {
@@ -85,9 +86,9 @@ Agent.prototype._init = function initSock(socket) {
     that._handle(msg, rsinfo, outSocket)
   })
 
-  if(this._opts.port){
+  if(this._opts.port) {
     this._sock.bind( this._opts.port );
-  };
+  }
 
   this._sock.on('error', function(err) {
     // we are skipping DNS errors
@@ -185,11 +186,48 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
     return
   }
 
-  if (!packet.confirmable && !req.multicast) {
-    delete this._msgIdToReq[packet.messageId]
+  var block1Buff = getOption(packet.options, 'Block1');
+  var block1;
+  if(block1Buff) {
+    block1 = parseBlockOption(block1Buff);
+    // check for error
+    if (!block1) {
+      req.sender.reset()
+      return req.emit('error', new Error('Failed to parse block1'))
+    }
   }
 
   req.sender.reset()
+
+  if(block1 && packet.ack) {
+    // var initialRequest = this._msgIdToReq[packet.messageId];
+    //If the client takes too long to respond then the retry sender will send
+    // another packet with the previous messageId, which we've already removed.
+    var segmentedSender = req.segmentedSender;
+    if(segmentedSender) {
+
+      //If there's more to send/receive, then carry on!
+      if(segmentedSender.remaining() > 0) {
+        delete this._msgIdToReq[req._packet.messageId]
+        req._packet.messageId = that._nextMessageId()
+        this._msgIdToReq[req._packet.messageId] = req
+        segmentedSender.receiveACK(packet, block1);
+        return;
+      } else {
+        delete req.segmentedSender;
+      }
+    } else {
+      console.log("Received Block1 ACK without SegmentedTransmission helper set. Hopefully just a retry?");
+      //throw new Error("Received a block1 ack without a segmented sender set");
+    }
+  }
+
+  
+  if (!packet.confirmable && !req.multicast) {
+    delete this._msgIdToReq[packet.messageId]
+  }
+  
+
 
   if (packet.code == '0.00')
     return
@@ -226,11 +264,11 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
         return req.emit('error', new Error('failed to create block2'))
       }
       req.setOption('Block2', block2Val)
+      req._packet.payload = null;
       req.sender.send(generate(req._packet))
 
       return
-    }
-    else {
+    } else {
       // get full payload
       packet.payload = req._totalPayload
       // clear the payload incase of block2
@@ -248,11 +286,9 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       return
     }
 
-  }
-  else if (block2) {
+  } else if (block2) {
     delete that._tkToReq[req._packet.token.readUInt32BE(0)]
-  }
-  else if (!req.url.observe && packet.token.length > 0) {
+  } else if (!req.url.observe && packet.token.length > 0) {
     // it is not, so delete the token
     delete that._tkToReq[packet.token.readUInt32BE(0)]
   }
@@ -320,17 +356,25 @@ Agent.prototype.request = function request(url) {
       packet.token = that._nextToken()
     }
 
-    try {
-      buf = generate(packet)
-    } catch(err) {
-      req.sender.reset()
-      return req.emit('error', err)
-    }
-
     that._msgIdToReq[packet.messageId] = req
     that._tkToReq[that._lastToken] = req
 
-    req.sender.send(buf, !packet.confirmable)
+    var block1Buff = getOption(packet.options, 'Block1');
+    if(block1Buff) {
+      // Setup for a segmented transmission
+      req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet, this);
+      req.segmentedSender.sendNext();
+
+    } else {
+      try {
+        buf = generate(packet)
+      } catch(err) {
+        req.sender.reset()
+        return req.emit('error', err)
+      }
+      req.sender.send(buf, !packet.confirmable)
+    }
+
   })
 
   req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host, url.retrySend)

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -21,6 +21,8 @@ var bl              = require('bl')
   , parseBlock2     = require('./helpers').parseBlock2
   , createBlock2    = require('./helpers').createBlock2
   , getOption       = require('./helpers').getOption
+  , removeOption       = require('./helpers').removeOption
+  , simplifyPacketForPrint = require('./helpers').simplifyPacketForPrint
   , maxToken        = Math.pow(2, 32)
   , maxMessageId    = Math.pow(2, 16)
   , pf              = require('./polyfill')
@@ -145,7 +147,6 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
           that._doClose()
         }
       }
-
   if (!req) {
     if (packet.token.length == 4) {
       req = this._tkToReq[packet.token.readUInt32BE(0)]
@@ -208,26 +209,26 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 
       //If there's more to send/receive, then carry on!
       if(segmentedSender.remaining() > 0) {
-        delete this._msgIdToReq[req._packet.messageId]
-        req._packet.messageId = that._nextMessageId()
-        this._msgIdToReq[req._packet.messageId] = req
-        segmentedSender.receiveACK(packet, block1);
+        if(segmentedSender.isCorrectACK(packet, block1)) {
+          delete this._msgIdToReq[req._packet.messageId]
+          req._packet.messageId = that._nextMessageId()
+          this._msgIdToReq[req._packet.messageId] = req
+          segmentedSender.receiveACK(packet, block1)
+        } else {
+          segmentedSender.resendPreviousPacket();
+        }
         return;
       } else {
+        // console.log("Packet received done");
+        removeOption(req._packet.options, "Block1");
         delete req.segmentedSender;
       }
-    } else {
-      console.log("Received Block1 ACK without SegmentedTransmission helper set. Hopefully just a retry?");
-      //throw new Error("Received a block1 ack without a segmented sender set");
     }
   }
 
-  
   if (!packet.confirmable && !req.multicast) {
     delete this._msgIdToReq[packet.messageId]
   }
-  
-
 
   if (packet.code == '0.00')
     return
@@ -328,6 +329,10 @@ Agent.prototype._nextMessageId = function nextToken() {
   return this._lastMessageId
 }
 
+/**
+ * Entry point for a new client-side request.
+ * @param {*} url A String representing a CoAP URL, or an object with the appropriate parameters. 
+ */
 Agent.prototype.request = function request(url) {
   this._init()
 
@@ -362,9 +367,8 @@ Agent.prototype.request = function request(url) {
     var block1Buff = getOption(packet.options, 'Block1');
     if(block1Buff) {
       // Setup for a segmented transmission
-      req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet, this);
+      req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet);
       req.segmentedSender.sendNext();
-
     } else {
       try {
         buf = generate(packet)
@@ -374,7 +378,6 @@ Agent.prototype.request = function request(url) {
       }
       req.sender.send(buf, !packet.confirmable)
     }
-
   })
 
   req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host, url.retrySend)

--- a/lib/block.js
+++ b/lib/block.js
@@ -1,7 +1,7 @@
 function isNullOrUndefined(obj) {
   return typeof obj === "undefined" || obj === null
 }
-const TwoPowTwenty = 1048575
+var TwoPowTwenty = 1048575
 /**
  * 
  * @param {Number} sequenceNumber The block sequence number.

--- a/lib/block.js
+++ b/lib/block.js
@@ -61,3 +61,10 @@ module.exports.parseBlockOption = function(buff) {
         blockSize: blockSize
     };
 }
+
+module.exports.exponentToByteSize = function(expo) {
+    return Math.pow(2, expo+4);
+}
+module.exports.byteSizeToExponent = function(byteSize) {
+    return Math.round(Math.log(byteSize) / Math.log(2) - 4);
+}

--- a/lib/block.js
+++ b/lib/block.js
@@ -1,7 +1,7 @@
 function isNullOrUndefined(obj) {
-    return typeof obj === "undefined" || obj === null;
+  return typeof obj === "undefined" || obj === null
 }
-const TwoPowTwenty = 1048575;
+const TwoPowTwenty = 1048575
 /**
  * 
  * @param {Number} sequenceNumber The block sequence number.
@@ -9,62 +9,62 @@ const TwoPowTwenty = 1048575;
  * @param {Number} blockSize 
  */
 module.exports.generateBlockOption = function(sequenceNumber, moreBlocks, blockSize) {
-    if(typeof sequenceNumber === "object") {
-        moreBlocks = sequenceNumber.moreBlocks;
-        blockSize = sequenceNumber.blockSize;
-        sequenceNumber = sequenceNumber.sequenceNumber;
-    }
+  if(typeof sequenceNumber === "object") {
+    moreBlocks = sequenceNumber.moreBlocks
+    blockSize = sequenceNumber.blockSize
+    sequenceNumber = sequenceNumber.sequenceNumber
+  }
 
-    if(isNullOrUndefined(sequenceNumber) || isNullOrUndefined(blockSize) || isNullOrUndefined(sequenceNumber)) {
-        throw new Error("Invalid parameters");
-    }
+  if(isNullOrUndefined(sequenceNumber) || isNullOrUndefined(blockSize) || isNullOrUndefined(sequenceNumber)) {
+    throw new Error("Invalid parameters")
+  }
 
-    if(sequenceNumber > TwoPowTwenty) {
-        throw new Error("Sequence number out of range");
-    }
+  if(sequenceNumber > TwoPowTwenty) {
+    throw new Error("Sequence number out of range")
+  }
 
-    var buff = Buffer.alloc(4);
+  var buff = Buffer.alloc(4)
 
-    var value = (sequenceNumber << 4) | ((moreBlocks?(1):(0)) << 3) | (blockSize & 7);
-    buff.writeInt32BE(value);
+  var value = (sequenceNumber << 4) | ((moreBlocks?(1):(0)) << 3) | (blockSize & 7)
+  buff.writeInt32BE(value)
 
-    if(sequenceNumber >= 4096) {
-        buff = buff.slice(1, 4);
-    } else if(sequenceNumber >= 16) {
-        buff = buff.slice(2, 4);
-    } else {
-        buff = buff.slice(3, 4);
-    }
-    
-    return buff;
+  if(sequenceNumber >= 4096) {
+    buff = buff.slice(1, 4)
+  } else if(sequenceNumber >= 16) {
+    buff = buff.slice(2, 4)
+  } else {
+    buff = buff.slice(3, 4)
+  }
+  
+  return buff
 }
 
 module.exports.parseBlockOption = function(buff) {
-    if(buff.length == 1) {
-        buff = Buffer.concat([Buffer.alloc(3), buff]);
-    } else if(buff.length == 2) {
-        buff = Buffer.concat([Buffer.alloc(2), buff]);
-    } else if(buff.length == 3) {
-        buff = Buffer.concat([Buffer.alloc(1), buff]);
-    } else {
-        throw new Error("Invalid block option buffer length. Must be 1, 2 or 3. It is " + buff.length);
-    }
-    var value = buff.readInt32BE();
+  if(buff.length == 1)
+    buff = Buffer.concat([Buffer.alloc(3), buff])
+  else if(buff.length == 2)
+    buff = Buffer.concat([Buffer.alloc(2), buff])
+  else if(buff.length == 3)
+    buff = Buffer.concat([Buffer.alloc(1), buff])
+  else
+    throw new Error("Invalid block option buffer length. Must be 1, 2 or 3. It is " + buff.length)
 
-    var sequenceNumber = (value >> 4) & TwoPowTwenty;
-    var moreBlocks = ((value & 8) === 8)?1:0;
-    var blockSize = value & 7;
+  var value = buff.readInt32BE()
 
-    return {
-        sequenceNumber: sequenceNumber,
-        moreBlocks: moreBlocks,
-        blockSize: blockSize
-    };
+  var sequenceNumber = (value >> 4) & TwoPowTwenty
+  var moreBlocks = ((value & 8) === 8)?1:0
+  var blockSize = value & 7
+
+  return {
+    sequenceNumber: sequenceNumber,
+    moreBlocks: moreBlocks,
+    blockSize: blockSize
+  }
 }
 
 module.exports.exponentToByteSize = function(expo) {
-    return Math.pow(2, expo+4);
+  return Math.pow(2, expo+4)
 }
 module.exports.byteSizeToExponent = function(byteSize) {
-    return Math.round(Math.log(byteSize) / Math.log(2) - 4);
+  return Math.round(Math.log(byteSize) / Math.log(2) - 4)
 }

--- a/lib/block.js
+++ b/lib/block.js
@@ -1,0 +1,63 @@
+function isNullOrUndefined(obj) {
+    return typeof obj === "undefined" || obj === null;
+}
+const TwoPowTwenty = 1048575;
+/**
+ * 
+ * @param {Number} sequenceNumber The block sequence number.
+ * @param {Boolean} moreBlocks If there are more blocks to follow
+ * @param {Number} blockSize 
+ */
+module.exports.generateBlockOption = function(sequenceNumber, moreBlocks, blockSize) {
+    if(typeof sequenceNumber === "object") {
+        moreBlocks = sequenceNumber.moreBlocks;
+        blockSize = sequenceNumber.blockSize;
+        sequenceNumber = sequenceNumber.sequenceNumber;
+    }
+
+    if(isNullOrUndefined(sequenceNumber) || isNullOrUndefined(blockSize) || isNullOrUndefined(sequenceNumber)) {
+        throw new Error("Invalid parameters");
+    }
+
+    if(sequenceNumber > TwoPowTwenty) {
+        throw new Error("Sequence number out of range");
+    }
+
+    var buff = Buffer.alloc(4);
+
+    var value = (sequenceNumber << 4) | ((moreBlocks?(1):(0)) << 3) | (blockSize & 7);
+    buff.writeInt32BE(value);
+
+    if(sequenceNumber >= 4096) {
+        buff = buff.slice(1, 4);
+    } else if(sequenceNumber >= 16) {
+        buff = buff.slice(2, 4);
+    } else {
+        buff = buff.slice(3, 4);
+    }
+    
+    return buff;
+}
+
+module.exports.parseBlockOption = function(buff) {
+    if(buff.length == 1) {
+        buff = Buffer.concat([Buffer.alloc(3), buff]);
+    } else if(buff.length == 2) {
+        buff = Buffer.concat([Buffer.alloc(2), buff]);
+    } else if(buff.length == 3) {
+        buff = Buffer.concat([Buffer.alloc(1), buff]);
+    } else {
+        throw new Error("Invalid block option buffer length. Must be 1, 2 or 3. It is " + buff.length);
+    }
+    var value = buff.readInt32BE();
+
+    var sequenceNumber = (value >> 4) & TwoPowTwenty;
+    var moreBlocks = ((value & 8) === 8)?1:0;
+    var blockSize = value & 7;
+
+    return {
+        sequenceNumber: sequenceNumber,
+        moreBlocks: moreBlocks,
+        blockSize: blockSize
+    };
+}

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,77 @@
+var debug = require('debug')('Block Cache')
+
+function expiry (cache, k) {
+  debug('delete expired cache entry, key:', k)
+  delete cache[k]
+}
+
+
+/**
+ * @class
+ * @constructor
+ * @template T
+ * @param {number} retentionPeriod 
+ * @param {()=>T} factory Function which returns new cache objects
+ */
+function BlockCache (retentionPeriod, factory) {
+  /** @type {{[k:string]:{payload:T,timeoutId:NodeJS.Timeout}}} */
+  this._cache = {}
+  this._retentionPeriod = retentionPeriod
+  this._factory = factory;
+}
+
+BlockCache.prototype.reset = function () {
+  for (var k in this._cache) {
+    debug('clean-up cache expiry timer, key:', k)
+    clearTimeout(this._cache[k].timeoutId)
+    delete this._cache[k]
+  }
+}
+
+BlockCache.prototype.add = 
+/** 
+ * @param {string} key
+ * @param {T} payload
+ */
+function (key, payload) {
+  if (this._cache.hasOwnProperty(key)) {
+    debug('reuse old cache entry, key:', key)
+    clearTimeout(this._cache[key].timeoutId)
+    this._cache[key].payload = payload
+  } else {
+    debug('add payload to cache, key:', key)
+    this._cache[key] = {payload: payload}
+  }
+  // setup new expiry timer
+  this._cache[key].timeoutId = setTimeout(expiry, this._retentionPeriod, this._cache, key)
+}
+
+BlockCache.prototype.remove = function (key) {
+  if (this._cache.hasOwnProperty(key)) {
+    debug('remove cache entry, key:', key)
+    clearTimeout(this._cache[key].timeoutId)
+    delete this._cache[key]
+    return true
+  }
+  return false
+}
+
+BlockCache.prototype.contains = function (key) {
+  return this._cache.hasOwnProperty(key)
+}
+
+BlockCache.prototype.get = function (key) {
+  return this._cache[key].payload
+}
+
+BlockCache.prototype.getWithDefaultInsert = function (key) {
+  if(this.contains(key)) {
+    return this._cache[key].payload
+  } else {
+    let def = this._factory()
+    this.add(key, def)
+    return def
+  }
+}
+
+module.exports = BlockCache;

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -17,6 +17,7 @@ function BlockCache (retentionPeriod, factory) {
   /** @type {{[k:string]:{payload:T,timeoutId:NodeJS.Timeout}}} */
   this._cache = {}
   this._retentionPeriod = retentionPeriod
+  debug("Created cache with " + (this._retentionPeriod/1000) + "s retention period");
   this._factory = factory;
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,8 +17,29 @@ var toBinary    = require('./option_converter').toBinary
   , capitalize  = require('capitalize')
   , isIgnored   = require('./option_converter').isIgnored
 
+
+var _getOptionObj = function(options, name) {
+  for (var i in options)
+    if (options[i].name == name)
+      return options[i]
+  return null
+}
+module.exports.getOption = getOption;
+
 module.exports.genAck = function(request) {
-  return {
+  var b1 = _getOptionObj(request.options, 'Block1');
+  if(b1 ) {//&& (request.code == '0.02' || request.code == '0.03')
+    return {
+        messageId: request.messageId
+      , token: request.token
+      , code: '2.31'
+      , options: [b1]
+      , confirmable: false
+      , ack: true
+      , reset: false
+    }
+  } else {
+    return {
       messageId: request.messageId
     , code: '0.00'
     , options: []
@@ -26,6 +47,8 @@ module.exports.genAck = function(request) {
     , ack: true
     , reset: false
   }
+  }
+
 }
 
 var optionAliases = {
@@ -126,18 +149,27 @@ module.exports.packetToMessage = function packetToMessage(dest, packet) {
   }
 }
 
+var hasOption = function(options, name) {
+  for (var i in options)
+    if (options[i].name == name)
+      return true;
+  return null
+}
+module.exports.hasOption = hasOption;
+
 /*
 get an option value from options
   options     array of object, in form {name: , value}
   name        name of the object wanted to retrive
   return      value, or null
 */
-module.exports.getOption = function getOption(options, name) {
+var getOption = function(options, name) {
   for (var i in options)
     if (options[i].name == name)
       return options[i].value
   return null
 }
+module.exports.getOption = getOption;
 
 /*
 get an option value from options
@@ -154,6 +186,20 @@ module.exports.removeOption = function removeOption(options, name) {
   }
   return false;
 }
+
+module.exports.simplifyPacketForPrint = function simplifyPacketForPrint(packetIn) {
+  var packet = Object.assign({}, packetIn);
+  packet.token = packet.token.toString("hex");
+  packet.payload = "Buff: " + packet.payload.length;
+  var newOptions = {};
+  for(var j in packet.options) {
+      var name = packet.options[j].name;
+      var hex = packet.options[j].value.toString("hex");
+      newOptions[name] = hex;
+  }
+  packet.options = newOptions;
+  return packet;
+};
 /*
 parse block2
   value       block2 value buffer

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -138,6 +138,22 @@ module.exports.getOption = function getOption(options, name) {
       return options[i].value
   return null
 }
+
+/*
+get an option value from options
+  options     array of object, in form {name: , value}
+  name        name of the object wanted to retrive
+  return      value, or null
+*/
+module.exports.removeOption = function removeOption(options, name) {
+  for (var i in options) {
+    if (options[i].name == name) {
+      delete options[i]
+      return true;
+    }
+  }
+  return false;
+}
 /*
 parse block2
   value       block2 value buffer

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -188,18 +188,18 @@ module.exports.removeOption = function removeOption(options, name) {
 }
 
 module.exports.simplifyPacketForPrint = function simplifyPacketForPrint(packetIn) {
-  var packet = Object.assign({}, packetIn);
-  packet.token = packet.token.toString("hex");
-  packet.payload = "Buff: " + packet.payload.length;
-  var newOptions = {};
+  var packet = Object.assign({}, packetIn)
+  packet.token = packet.token.toString("hex")
+  packet.payload = "Buff: " + packet.payload.length
+  var newOptions = {}
   for(var j in packet.options) {
-      var name = packet.options[j].name;
-      var hex = packet.options[j].value.toString("hex");
-      newOptions[name] = hex;
+      var name = packet.options[j].name
+      var hex = packet.options[j].value.toString("hex")
+      newOptions[name] = hex
   }
-  packet.options = newOptions;
-  return packet;
-};
+  packet.options = newOptions
+  return packet
+}
 /*
 parse block2
   value       block2 value buffer

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,28 +20,8 @@ var toBinary    = require('./option_converter').toBinary
   , isIgnored   = require('./option_converter').isIgnored
 
 
-var _getOptionObj = function(options, name) {
-  for (var i in options)
-    if (options[i].name == name)
-      return options[i]
-  return null
-}
-module.exports.getOption = getOption;
-
 module.exports.genAck = function(request) {
-  var b1 = _getOptionObj(request.options, 'Block1');
-  if(b1 ) {//&& (request.code == '0.02' || request.code == '0.03')
-    return {
-        messageId: request.messageId
-      , token: request.token
-      , code: '2.31'
-      , options: [b1]
-      , confirmable: false
-      , ack: true
-      , reset: false
-    }
-  } else {
-    return {
+  return {
       messageId: request.messageId
     , code: '0.00'
     , options: []
@@ -49,8 +29,6 @@ module.exports.genAck = function(request) {
     , ack: true
     , reset: false
   }
-  }
-
 }
 
 var optionAliases = {

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,5 +1,7 @@
-const {generate} = require('coap-packet')
-const {generateBlockOption, byteSizeToExponent, exponentToByteSize} = require('./block')
+var generate = require('coap-packet').generate
+ , generateBlockOption = require('./block').generateBlockOption
+ , byteSizeToExponent = require('./block').byteSizeToExponent
+ , exponentToByteSize = require('./block').exponentToByteSize;
 
 
 function SegmentedTransmission(blockSize, req, packet) {

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,58 +1,58 @@
-const {generate} = require('coap-packet');
-const {generateBlockOption, byteSizeToExponent, exponentToByteSize} = require('./block');
+const {generate} = require('coap-packet')
+const {generateBlockOption, byteSizeToExponent, exponentToByteSize} = require('./block')
 
 
 function SegmentedTransmission(blockSize, req, packet) {
-    if(blockSize < 0 || blockSize > 6) {
-        throw new Error("invalid block size " + blockSize);
-    }
+  if(blockSize < 0 || blockSize > 6) {
+    throw new Error("invalid block size " + blockSize)
+  }
 
-    this.blockState = {
-        sequenceNumber: 0,
-        moreBlocks: false,
-        blockSize: 0
-    };
+  this.blockState = {
+    sequenceNumber: 0,
+    moreBlocks: false,
+    blockSize: 0
+  }
 
-    this.setBlockSizeExp(blockSize);
+  this.setBlockSizeExp(blockSize)
 
-    this.totalLength = packet.payload.length;
-    this.currentByte = 0;
-    this.lastByte = 0;
+  this.totalLength = packet.payload.length
+  this.currentByte = 0
+  this.lastByte = 0
 
-    this.req = req;
-    this.payload = packet.payload;
-    this.packet = packet;
+  this.req = req
+  this.payload = packet.payload
+  this.packet = packet
 
-    this.packet.payload = null;
-    this.resendCount = 0;
+  this.packet.payload = null
+  this.resendCount = 0
 }
 
 SegmentedTransmission.prototype.setBlockSizeExp = function setBlockSizeExp(blockSizeExp) {
-    this.blockState.blockSize = blockSizeExp;
-    this.byteSize = exponentToByteSize(blockSizeExp);
+  this.blockState.blockSize = blockSizeExp
+  this.byteSize = exponentToByteSize(blockSizeExp)
 }
 
 SegmentedTransmission.prototype.updateBlockState = function updateBlockState() {
-    this.blockState.sequenceNumber = this.currentByte / this.byteSize;
-    this.blockState.moreBlocks = ((this.currentByte + this.byteSize) < this.totalLength)?1:0;
+  this.blockState.sequenceNumber = this.currentByte / this.byteSize
+  this.blockState.moreBlocks = ((this.currentByte + this.byteSize) < this.totalLength)?1:0
 
-    this.req.setOption("Block1", generateBlockOption(this.blockState));
+  this.req.setOption("Block1", generateBlockOption(this.blockState))
 }
 
 SegmentedTransmission.prototype.isCorrectACK = function isCorrectACK(packet, retBlockState) {
-    return retBlockState.sequenceNumber == this.blockState.sequenceNumber// && packet.code == "2.31"
+  return retBlockState.sequenceNumber == this.blockState.sequenceNumber// && packet.code == "2.31"
 }
 
 SegmentedTransmission.prototype.resendPreviousPacket = function resendPreviousPacket() {
-    if(this.resendCount < 5) {
-        this.currentByte = this.lastByte;
-        if(this.remaining() > 0) {
-            this.sendNext();
-        }
-        this.resendCount++;
-    } else {
-        throw new Error("Too many block re-transfers");
+  if(this.resendCount < 5) {
+    this.currentByte = this.lastByte
+    if(this.remaining() > 0) {
+      this.sendNext()
     }
+    this.resendCount++
+  } else {
+    throw new Error("Too many block re-transfers")
+  }
 }
 
 /**
@@ -62,45 +62,45 @@ SegmentedTransmission.prototype.resendPreviousPacket = function resendPreviousPa
  * @returns {Boolean} Returns true if the ACK was for the correct block. 
  */
 SegmentedTransmission.prototype.receiveACK = function receiveACK(packet, retBlockState) {
-    if(this.blockState.blockSize !== retBlockState.blockSize) {
-        this.setBlockSizeExp(retBlockState.blockSize);
-    }
+  if(this.blockState.blockSize !== retBlockState.blockSize) {
+    this.setBlockSizeExp(retBlockState.blockSize)
+  }
 
-    if(this.remaining() > 0) {
-        this.sendNext();
-    }
-    this.resendCount = 0;
+  if(this.remaining() > 0) {
+    this.sendNext()
+  }
+  this.resendCount = 0
 }
 
 SegmentedTransmission.prototype.remaining = function remaining() {
-    return this.totalLength - this.currentByte;
+  return this.totalLength - this.currentByte
 }
 
 SegmentedTransmission.prototype.sendNext = function sendNext() {
-    var blockLength = Math.min(this.totalLength - this.currentByte, this.byteSize);
-    var subBuffer = this.payload.slice(this.currentByte, this.currentByte + blockLength);
-    this.updateBlockState();
+  var blockLength = Math.min(this.totalLength - this.currentByte, this.byteSize)
+  var subBuffer = this.payload.slice(this.currentByte, this.currentByte + blockLength)
+  this.updateBlockState()
 
-    this.packet.ack = false;
-    this.packet.reset = false;
-    this.packet.confirmable = true;
+  this.packet.ack = false
+  this.packet.reset = false
+  this.packet.confirmable = true
 
-    this.packet.payload = subBuffer;
+  this.packet.payload = subBuffer
 
 
-    this.lastByte = this.currentByte;
-    this.currentByte += blockLength;
-    var buf;
-    
-    try {
-      buf = generate(this.packet)
-    } catch(err) {
-      this.req.sender.reset()
-      return this.req.emit('error', err)
-    }
-    this.req.sender.send(buf, !this.packet.confirmable)
+  this.lastByte = this.currentByte
+  this.currentByte += blockLength
+  var buf
+  
+  try {
+    buf = generate(this.packet)
+  } catch(err) {
+    this.req.sender.reset()
+    return this.req.emit('error', err)
+  }
+  this.req.sender.send(buf, !this.packet.confirmable)
 }
 
 
 
-module.exports.SegmentedTransmission = SegmentedTransmission;
+module.exports.SegmentedTransmission = SegmentedTransmission

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,0 +1,81 @@
+const {generate} = require('coap-packet');
+const {generateBlockOption} = require('./block');
+
+
+function SegmentedTransmission(blockSize, req, packet, outgoingMessage) {
+    if(blockSize < 0 || blockSize > 6) {
+        throw new Error("invalid block size " + blockSize);
+    }
+
+    this.blockState = {
+        sequenceNumber: 0,
+        moreBlocks: false,
+        blockSize: 0
+    };
+
+    this.setBlockSizeExp(blockSize);
+
+    this.totalLength = packet.payload.length;
+    this.currentByte = 0;
+
+    this.req = req;
+    this.payload = packet.payload;
+    this.packet = packet;
+    this.outgoingMessage = outgoingMessage;
+
+    this.packet.payload = null;
+}
+
+SegmentedTransmission.prototype.setBlockSizeExp = function setBlockSizeExp(blockSizeExp) {
+    this.blockState.blockSize = blockSizeExp;
+    this.byteSize = Math.pow(2, blockSizeExp+4);
+}
+
+SegmentedTransmission.prototype.updateBlockState = function updateBlockState() {
+    this.blockState.sequenceNumber = this.currentByte / this.byteSize;
+    this.blockState.moreBlocks = ((this.currentByte + this.byteSize) < this.totalLength)?1:0;
+
+    this.req.setOption("Block1", generateBlockOption(this.blockState));
+}
+
+/**
+ * 
+ * @param {Packet} packet The packet received which contained the ack
+ * @param {Object} retBlockState The received block state from the other end 
+ */
+SegmentedTransmission.prototype.receiveACK = function receiveACK(packet, retBlockState) {
+    if(this.blockState.blockSize !== retBlockState.blockSize) {
+        this.setBlockSizeExp(retBlockState.blockSize);
+    }
+    if(this.remaining() > 0) {
+        this.sendNext();
+    }
+}
+
+SegmentedTransmission.prototype.remaining = function remaining() {
+    return this.totalLength - this.currentByte;
+}
+
+SegmentedTransmission.prototype.sendNext = function sendNext() {
+    var blockLength = Math.min(this.totalLength - this.currentByte, this.byteSize);
+    var subBuffer = this.payload.slice(this.currentByte, this.currentByte + blockLength);
+    this.updateBlockState();
+
+    this.packet.payload = subBuffer;
+
+    this.currentByte += blockLength;
+    var buf;
+    
+    try {
+      buf = generate(this.packet)
+    } catch(err) {
+      this.req.sender.reset()
+      return this.req.emit('error', err)
+    }
+    
+    this.req.sender.send(buf, !this.packet.confirmable)
+}
+
+
+
+module.exports.SegmentedTransmission = SegmentedTransmission;

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,8 +1,8 @@
 const {generate} = require('coap-packet');
-const {generateBlockOption} = require('./block');
+const {generateBlockOption, byteSizeToExponent, exponentToByteSize} = require('./block');
 
 
-function SegmentedTransmission(blockSize, req, packet, outgoingMessage) {
+function SegmentedTransmission(blockSize, req, packet) {
     if(blockSize < 0 || blockSize > 6) {
         throw new Error("invalid block size " + blockSize);
     }
@@ -17,18 +17,19 @@ function SegmentedTransmission(blockSize, req, packet, outgoingMessage) {
 
     this.totalLength = packet.payload.length;
     this.currentByte = 0;
+    this.lastByte = 0;
 
     this.req = req;
     this.payload = packet.payload;
     this.packet = packet;
-    this.outgoingMessage = outgoingMessage;
 
     this.packet.payload = null;
+    this.resendCount = 0;
 }
 
 SegmentedTransmission.prototype.setBlockSizeExp = function setBlockSizeExp(blockSizeExp) {
     this.blockState.blockSize = blockSizeExp;
-    this.byteSize = Math.pow(2, blockSizeExp+4);
+    this.byteSize = exponentToByteSize(blockSizeExp);
 }
 
 SegmentedTransmission.prototype.updateBlockState = function updateBlockState() {
@@ -38,18 +39,37 @@ SegmentedTransmission.prototype.updateBlockState = function updateBlockState() {
     this.req.setOption("Block1", generateBlockOption(this.blockState));
 }
 
+SegmentedTransmission.prototype.isCorrectACK = function isCorrectACK(packet, retBlockState) {
+    return retBlockState.sequenceNumber == this.blockState.sequenceNumber// && packet.code == "2.31"
+}
+
+SegmentedTransmission.prototype.resendPreviousPacket = function resendPreviousPacket() {
+    if(this.resendCount < 5) {
+        this.currentByte = this.lastByte;
+        if(this.remaining() > 0) {
+            this.sendNext();
+        }
+        this.resendCount++;
+    } else {
+        throw new Error("Too many block re-transfers");
+    }
+}
+
 /**
  * 
  * @param {Packet} packet The packet received which contained the ack
  * @param {Object} retBlockState The received block state from the other end 
+ * @returns {Boolean} Returns true if the ACK was for the correct block. 
  */
 SegmentedTransmission.prototype.receiveACK = function receiveACK(packet, retBlockState) {
     if(this.blockState.blockSize !== retBlockState.blockSize) {
         this.setBlockSizeExp(retBlockState.blockSize);
     }
+
     if(this.remaining() > 0) {
         this.sendNext();
     }
+    this.resendCount = 0;
 }
 
 SegmentedTransmission.prototype.remaining = function remaining() {
@@ -61,8 +81,14 @@ SegmentedTransmission.prototype.sendNext = function sendNext() {
     var subBuffer = this.payload.slice(this.currentByte, this.currentByte + blockLength);
     this.updateBlockState();
 
+    this.packet.ack = false;
+    this.packet.reset = false;
+    this.packet.confirmable = true;
+
     this.packet.payload = subBuffer;
 
+
+    this.lastByte = this.currentByte;
     this.currentByte += blockLength;
     var buf;
     
@@ -72,7 +98,6 @@ SegmentedTransmission.prototype.sendNext = function sendNext() {
       this.req.sender.reset()
       return this.req.emit('error', err)
     }
-    
     this.req.sender.send(buf, !this.packet.confirmable)
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,6 +35,7 @@ var dgram           = require('dgram')
   , middlewares     = require('./middlewares')
   , debug           = require('debug')('CoAP Server')
   , parseBlockOption= require('./block').parseBlockOption
+  , BlockCache           = require('./cache')
 
 
 function handleEnding(err) {
@@ -97,10 +98,15 @@ function CoAPServer(options, listener) {
                     value.sender.reset()
                 }
   })
-
+  
   this._series = series()
-  this._block1Cache = {}
-  this._block2Cache = {}
+  
+  this._block1Cache = new BlockCache(parameters.exchangeLifetime * 1000, () => {
+    return {};
+  })
+  this._block2Cache = new BlockCache(parameters.exchangeLifetime * 1000, () => {
+    return null;
+  });
 
   if (listener)
     this.on('request', listener)
@@ -274,21 +280,11 @@ CoAPServer.prototype.close = function(done) {
     this._lru.reset()
   }
 
-  // cancel cache entry expiry timers
-  for (var k in this._block2Cache) {
-    if (this._block2Cache.hasOwnProperty(k)) {
-      debug('clean-up cache expiry timer, key:', k)
-      clearTimeout(this._block2Cache[k].timeoutId)
-      delete this._block2Cache[k]
-    }
-  }
+  this._block2Cache.reset();
+  this._block1Cache.reset();
+
 
   return this
-}
-
-function expiry(block2cache, k) {
-  debug('delete expired cache entry, key:', k)
-  delete block2cache[k]
 }
 
 /**
@@ -372,21 +368,9 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     response.statusCode = '2.05'
     response._request = request._packet
     response._cachekey = toCacheKey(rsinfo.address, rsinfo.port, packet)
-  
-    var block2cache = that._block2Cache
+
     //inject this function so the response can add an entry to the cache
-    response._addCacheEntry = function(key, payload) {
-      if (block2cache.hasOwnProperty(key)) {
-        debug('reuse old cache entry, key:', key)
-        clearTimeout(block2cache[key].timeoutId) // cancel old expiry timer
-        block2cache[key].payload = payload
-      } else {
-        debug('add payload to cache, key:', key)
-        block2cache[key] = {payload: payload}
-      }
-      // setup new expiry timer
-      block2cache[key].timeoutId = setTimeout(expiry, parameters.exchangeLifetime * 1000, block2cache, key)
-    }
+    response._addCacheEntry = that._block2Cache.add.bind(that._block2Cache)
 
     return response
   }
@@ -410,16 +394,14 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     }
 
     if (requestedBlockOption.num < 1) {
-      if (this._block2Cache.hasOwnProperty(response._cachekey)) {
-        debug('first block2 request, remove old entry from cache, key:', response._cachekey)
-        clearTimeout(this._block2Cache[response._cachekey].timeoutId)
-        delete this._block2Cache[response._cachekey]
+      if(this._block2Cache.remove(response._cachekey)) {
+        debug('first block2 request, removed old entry from cache')
       }
     } else {
       debug('check if packet token is in cache, key:', response._cachekey)
-      if (this._block2Cache.hasOwnProperty(response._cachekey)) {
+      if (this._block2Cache.contains(response._cachekey)) {
         debug('found cached payload, key:', response._cachekey)
-        response.end(this._block2Cache[response._cachekey].payload)
+        response.end(this._block2Cache.get(response._cachekey));
         cachedResponseSend = true
       }
     }
@@ -427,51 +409,52 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   {
     var block1Buff = getOption(response._request.options, 'Block1')
     if(block1Buff) {
-      var blockState = parseBlockOption(block1Buff);
+      var blockState = parseBlockOption(block1Buff)
 
       if(blockState) {
-        if(request.payload.length == 0 && !blockState.moreBlocks) {
-          console.log("Cleaning up the packet. Received a Block1 message option but that's already been received");
-          removeOption(packet.options, "Block1");
+        cachedResponseSend = true
 
-        } else {
-          cachedResponseSend = blockState.moreBlocks;
-          response.code = "2.04";
-          response.setOption("Block1", block1Buff);
+        response.code = "2.04"
+        response.setOption("Block1", block1Buff)
+
+        /** @type {{[k:string]:Buffer}} */
+        let cachedData = this._block1Cache.getWithDefaultInsert(response._cachekey)
+        var blockByteSize = Math.pow(2, 4 + blockState.blockSize)
+        // Store in the cache object, use the byte index as the key
+        cachedData[blockState.sequenceNumber * blockByteSize] = request.payload
   
-          if (!this._block1Cache.hasOwnProperty(response._cachekey)) {
-            this._block1Cache[response._cachekey] = {};
-          }
-          var blockByteSize = Math.pow(2, 4+blockState.blockSize);
-          this._block1Cache[response._cachekey][blockState.sequenceNumber * blockByteSize] = request.payload;
-  
-  
-          if(!blockState.moreBlocks) {
-            var cachedData = this._block1Cache[response._cachekey];
-            var byteOffsets = Object.getOwnPropertyNames(cachedData);
-            var next = 0;
-            var concat = Buffer.alloc(blockState.sequenceNumber * blockByteSize + request.payload.length);
-            for(var i = 0; i < byteOffsets.length; i++) {
-              if(byteOffsets[i] == next) {
-                var buff = cachedData[byteOffsets[i]];
-                buff.copy(concat, next, 0, buff.length);
-                next += buff.length;
-              }
-            }
-            delete this._block1Cache[response._cachekey];
-            if(next == concat.length) {
-              request.payload = concat;
-              this.emit('request', request, response)
+        if(!blockState.moreBlocks) {
+          var byteOffsets = Object.keys(cachedData)
+            .map((str) => {
+              return parseInt(str)
+            }).sort((a, b) => {
+              return a - b;
+            });
+          var byteTotalSum = blockState.sequenceNumber * blockByteSize + request.payload.length
+          var next = 0
+          var concat = Buffer.alloc(byteTotalSum)
+
+          for(var i = 0; i < byteOffsets.length; i++) {
+            if(byteOffsets[i] == next) {
+              var buff = cachedData[byteOffsets[i]];
+              buff.copy(concat, next, 0, buff.length);
+              next += buff.length;
             } else {
-              console.log("Got dupe packet");
-              throw new Error("Last byte index is not equal to the concat buffer length!");
+              throw new Error("Byte offset not the next in line...");
             }
-          } else {
-            // response.end();
           }
-          return
+          
+          this._block1Cache.remove(response._cachekey)
+
+          if(next == concat.length) {
+            request.payload = concat;
+            cachedResponseSend = false;
+            // this.emit('request', request, response)
+          } else {
+            console.log("Got dupe packet");
+            throw new Error("Last byte index is not equal to the concat buffer length!");
+          }
         }
-        
       } else {
         throw new Error("Invalid block state" + blockState);
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,6 +31,7 @@ var dgram           = require('dgram')
   , removeOption    = require('./helpers').removeOption
   , isNumeric       = require('./helpers').isNumeric
   , isBoolean       = require('./helpers').isBoolean
+  , simplifyPacketForPrint = require('./helpers').simplifyPacketForPrint
   , middlewares     = require('./middlewares')
   , debug           = require('debug')('CoAP Server')
   , parseBlockOption= require('./block').parseBlockOption
@@ -290,6 +291,11 @@ function expiry(block2cache, k) {
   delete block2cache[k]
 }
 
+/**
+ * Entry point for a new datagram from the client.
+ * @param {Packet} packet The packet that was sent from the client.
+ * @param {Object} rsinfo Connection info 
+ */
 CoAPServer.prototype._handle = function(packet, rsinfo) {
 
   if (packet.code[0] !== '0') {
@@ -332,18 +338,16 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   }
 
   packet.piggybackReplyMs = this._options.piggybackReplyMs;
-
   var generateResponse = function() {
     var response = new Message(packet, function(response, packet) {
       var buf
         , sender = new RetrySend(sock, rsinfo.port, rsinfo.address)
-  
+
       try {
         buf = generate(packet)
       } catch(err) {
         return response.emit('error', err)
       }
-  
       if (Message === OutMessage) {
         sender.on('error', response.emit.bind(response, 'error'))
       } else {
@@ -426,41 +430,48 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       var blockState = parseBlockOption(block1Buff);
 
       if(blockState) {
-        cachedResponseSend = blockState.moreBlocks;
-        response.code = "2.04";
-        response.setOption("Block1", block1Buff);
+        if(request.payload.length == 0 && !blockState.moreBlocks) {
+          console.log("Cleaning up the packet. Received a Block1 message option but that's already been received");
+          removeOption(packet.options, "Block1");
 
-        if (!this._block1Cache.hasOwnProperty(response._cachekey)) {
-          this._block1Cache[response._cachekey] = {};
-        }
-        var blockByteSize = Math.pow(2, 4+blockState.blockSize);
-        this._block1Cache[response._cachekey][blockState.sequenceNumber * blockByteSize] = request.payload;
-
-
-        if(!blockState.moreBlocks) {
-          var cachedData = this._block1Cache[response._cachekey];
-          var byteOffsets = Object.getOwnPropertyNames(cachedData);
-          var next = 0;
-          var concat = Buffer.alloc(blockState.sequenceNumber * blockByteSize + request.payload.length);
-          for(var i = 0; i < byteOffsets.length; i++) {
-            if(byteOffsets[i] == next) {
-              var buff = cachedData[byteOffsets[i]];
-              buff.copy(concat, next, 0, buff.length);
-              next += buff.length;
-            }
-          }
-          delete this._block1Cache[response._cachekey];
-          if(next == concat.length) {
-            request.payload = concat;
-            this.emit('request', request, response)
-          } else {
-            console.log("Got dupe packet");
-            throw new Error("Last byte index is not equal to the concat buffer length!");
-          }
         } else {
-          response.end();
+          cachedResponseSend = blockState.moreBlocks;
+          response.code = "2.04";
+          response.setOption("Block1", block1Buff);
+  
+          if (!this._block1Cache.hasOwnProperty(response._cachekey)) {
+            this._block1Cache[response._cachekey] = {};
+          }
+          var blockByteSize = Math.pow(2, 4+blockState.blockSize);
+          this._block1Cache[response._cachekey][blockState.sequenceNumber * blockByteSize] = request.payload;
+  
+  
+          if(!blockState.moreBlocks) {
+            var cachedData = this._block1Cache[response._cachekey];
+            var byteOffsets = Object.getOwnPropertyNames(cachedData);
+            var next = 0;
+            var concat = Buffer.alloc(blockState.sequenceNumber * blockByteSize + request.payload.length);
+            for(var i = 0; i < byteOffsets.length; i++) {
+              if(byteOffsets[i] == next) {
+                var buff = cachedData[byteOffsets[i]];
+                buff.copy(concat, next, 0, buff.length);
+                next += buff.length;
+              }
+            }
+            delete this._block1Cache[response._cachekey];
+            if(next == concat.length) {
+              request.payload = concat;
+              this.emit('request', request, response)
+            } else {
+              console.log("Got dupe packet");
+              throw new Error("Last byte index is not equal to the concat buffer length!");
+            }
+          } else {
+            // response.end();
+          }
+          return
         }
-        return
+        
       } else {
         throw new Error("Invalid block state" + blockState);
       }
@@ -505,10 +516,14 @@ var maxBlock2 = Math.pow(2, Math.floor(Math.log(parameters.maxPacketSize)/Math.l
 if (maxBlock2 > Math.pow(2, (6+4)))
   maxBlock2 = Math.pow(2, (6+4))
 
+/**
+ * Entry point for a response from the server
+ * @param {Buffer} payload A buffer-like object containing data to send back to the client.
+ */
 OutMessage.prototype.end= function(payload) {
   var that = this
   
-  removeOption(this._request.options, 'Block1');  
+  // removeOption(this._request.options, 'Block1');  
   var block2Buff = getOption(this._request.options, 'Block2')
   var requestedBlockOption
   // if we got blockwise (2) request
@@ -550,7 +565,7 @@ OutMessage.prototype.end= function(payload) {
     that.statusCode = '4.02'
     return OutgoingMessage.prototype.end.call(that)
   }
-
+  
   var block2 = createBlock2({
     moreBlock2: isLastBlock,
     num: requestedBlockOption.num,

--- a/lib/server.js
+++ b/lib/server.js
@@ -306,7 +306,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
 
   var sock      = this._sock
     , lru       = this._lru
-    , acks      = this._acks
+    // , acks      = this._acks
     , cached    = lru.peek(toKey(rsinfo.address, rsinfo.port, packet, true))
     , Message   = OutMessage
     , that = this
@@ -332,6 +332,8 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       // it is not a GET
       return this._sendError(new Buffer('Observe can only be present with a GET'), rsinfo)
   }
+
+  var cache_key = toCacheKey(rsinfo.address, rsinfo.port, packet);
 
   packet.piggybackReplyMs = this._options.piggybackReplyMs;
   var generateResponse = function() {
@@ -367,7 +369,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   
     response.statusCode = '2.05'
     response._request = request._packet
-    response._cachekey = toCacheKey(rsinfo.address, rsinfo.port, packet)
+    response._cachekey = cache_key
 
     //inject this function so the response can add an entry to the cache
     response._addCacheEntry = that._block2Cache.add.bind(that._block2Cache)
@@ -375,16 +377,12 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     return response
   }
 
+  response = generateResponse()
   request.rsinfo = rsinfo
-
-  response = generateResponse();
   
-
-  //return cached value for blockwise requests
-  var cachedResponseSend = false
   if (packet.token && packet.token.length > 0) {
     // return cached value only if this request is not the first block request
-    var block2Buff = getOption(response._request.options, 'Block2')
+    var block2Buff = getOption(packet.options, 'Block2')
     var requestedBlockOption
     if (block2Buff) {
       requestedBlockOption = parseBlock2(block2Buff)
@@ -394,46 +392,42 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     }
 
     if (requestedBlockOption.num < 1) {
-      if(this._block2Cache.remove(response._cachekey)) {
+      if(this._block2Cache.remove(cache_key)) {
         debug('first block2 request, removed old entry from cache')
       }
     } else {
-      debug('check if packet token is in cache, key:', response._cachekey)
-      if (this._block2Cache.contains(response._cachekey)) {
-        debug('found cached payload, key:', response._cachekey)
-        response.end(this._block2Cache.get(response._cachekey));
-        cachedResponseSend = true
+      debug('check if packet token is in cache, key:', cache_key)
+      if (this._block2Cache.contains(cache_key)) {
+        debug('found cached payload, key:', cache_key)
+        response.end(this._block2Cache.get(cache_key));
+        return;
       }
     }
   }
   {
-    var block1Buff = getOption(response._request.options, 'Block1')
+    var block1Buff = getOption(packet.options, 'Block1')
     if(block1Buff) {
       var blockState = parseBlockOption(block1Buff)
 
       if(blockState) {
-        cachedResponseSend = true
-
-        response.code = "2.04"
-        response.setOption("Block1", block1Buff)
-
         /** @type {{[k:string]:Buffer}} */
-        let cachedData = this._block1Cache.getWithDefaultInsert(response._cachekey)
+        let cachedData = this._block1Cache.getWithDefaultInsert(cache_key)
         var blockByteSize = Math.pow(2, 4 + blockState.blockSize)
+        var incomingByteIndex = blockState.sequenceNumber * blockByteSize
         // Store in the cache object, use the byte index as the key
-        cachedData[blockState.sequenceNumber * blockByteSize] = request.payload
+        cachedData[incomingByteIndex] = request.payload
   
         if(!blockState.moreBlocks) {
+          // Last block
           var byteOffsets = Object.keys(cachedData)
             .map((str) => {
               return parseInt(str)
             }).sort((a, b) => {
               return a - b;
             });
-          var byteTotalSum = blockState.sequenceNumber * blockByteSize + request.payload.length
+          var byteTotalSum = incomingByteIndex + request.payload.length
           var next = 0
           var concat = Buffer.alloc(byteTotalSum)
-
           for(var i = 0; i < byteOffsets.length; i++) {
             if(byteOffsets[i] == next) {
               var buff = cachedData[byteOffsets[i]];
@@ -444,16 +438,19 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
             }
           }
           
-          this._block1Cache.remove(response._cachekey)
+          this._block1Cache.remove(cache_key)
 
           if(next == concat.length) {
-            request.payload = concat;
-            cachedResponseSend = false;
-            // this.emit('request', request, response)
+            request.payload = concat
           } else {
-            console.log("Got dupe packet");
             throw new Error("Last byte index is not equal to the concat buffer length!");
           }
+        } else {
+          // More blocks to come. ACK this block
+          response.code = "2.31"
+          response.setOption("Block1", block1Buff)
+          response.end();
+          return;
         }
       } else {
         throw new Error("Invalid block state" + blockState);
@@ -461,10 +458,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     }
   }
 
-  if (!cachedResponseSend) {
-    debug('no cached entry found, emit request to upper layer');
-    this.emit('request', request, response)
-  }
+  this.emit('request', request, response)
 }
 
 function toCacheKey(address, port, packet) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -227,8 +227,8 @@ CoAPServer.prototype.listen = function(port, address, done) {
       if (that._multicastInterface) {
         that._sock.addMembership(that._multicastAddress, that._multicastInterface)
       } else {
-        allAddresses(that._options.type).forEach(function(interface) {
-            that._sock.addMembership(that._multicastAddress, interface)
+        allAddresses(that._options.type).forEach(function(intrface) {
+            that._sock.addMembership(that._multicastAddress, intrface)
         })
       }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,5 @@
+
+
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
  *
@@ -26,10 +28,12 @@ var dgram           = require('dgram')
   , parseBlock2     = require('./helpers').parseBlock2
   , createBlock2    = require('./helpers').createBlock2
   , getOption       = require('./helpers').getOption
+  , removeOption    = require('./helpers').removeOption
   , isNumeric       = require('./helpers').isNumeric
   , isBoolean       = require('./helpers').isBoolean
   , middlewares     = require('./middlewares')
   , debug           = require('debug')('CoAP Server')
+  , parseBlockOption= require('./block').parseBlockOption
 
 
 function handleEnding(err) {
@@ -94,6 +98,7 @@ function CoAPServer(options, listener) {
   })
 
   this._series = series()
+  this._block1Cache = {}
   this._block2Cache = {}
 
   if (listener)
@@ -313,8 +318,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       cached.response.end()
     }
     return lru.del(toKey(rsinfo.address, rsinfo.port, packet, false))
-  }
-  else if (packet.ack || packet.reset) {
+  } else if (packet.ack || packet.reset) {
     return // nothing to do, ignoring silently
   }
 
@@ -328,56 +332,65 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   }
 
   packet.piggybackReplyMs = this._options.piggybackReplyMs;
-  response = new Message(packet, function(response, packet) {
-    var buf
-      , sender = new RetrySend(sock, rsinfo.port, rsinfo.address)
 
-    try {
-      buf = generate(packet)
-    } catch(err) {
-      return response.emit('error', err)
+  var generateResponse = function() {
+    var response = new Message(packet, function(response, packet) {
+      var buf
+        , sender = new RetrySend(sock, rsinfo.port, rsinfo.address)
+  
+      try {
+        buf = generate(packet)
+      } catch(err) {
+        return response.emit('error', err)
+      }
+  
+      if (Message === OutMessage) {
+        sender.on('error', response.emit.bind(response, 'error'))
+      } else {
+        buf.response = response
+        sender.on('error', function() {
+          response.end()
+        })
+      }
+  
+      var key = toKey(rsinfo.address, rsinfo.port,
+          packet, packet.ack || !packet.confirmable)
+      lru.set(key, buf)
+      buf.sender = sender
+  
+      if (that._options.sendAcksForNonConfirmablePackets || packet.confirmable) {
+        sender.send(buf, packet.ack || packet.reset || packet.confirmable === false)
+      } else {
+        debug('OMIT ACK PACKAGE')
+      }
+    })
+  
+    response.statusCode = '2.05'
+    response._request = request._packet
+    response._cachekey = toCacheKey(rsinfo.address, rsinfo.port, packet)
+  
+    var block2cache = that._block2Cache
+    //inject this function so the response can add an entry to the cache
+    response._addCacheEntry = function(key, payload) {
+      if (block2cache.hasOwnProperty(key)) {
+        debug('reuse old cache entry, key:', key)
+        clearTimeout(block2cache[key].timeoutId) // cancel old expiry timer
+        block2cache[key].payload = payload
+      } else {
+        debug('add payload to cache, key:', key)
+        block2cache[key] = {payload: payload}
+      }
+      // setup new expiry timer
+      block2cache[key].timeoutId = setTimeout(expiry, parameters.exchangeLifetime * 1000, block2cache, key)
     }
 
-    if (Message === OutMessage) {
-      sender.on('error', response.emit.bind(response, 'error'))
-    } else {
-      buf.response = response
-      sender.on('error', function() {
-        response.end()
-      })
-    }
-
-    var key = toKey(rsinfo.address, rsinfo.port,
-        packet, packet.ack || !packet.confirmable)
-    lru.set(key, buf)
-    buf.sender = sender
-
-    if (that._options.sendAcksForNonConfirmablePackets || packet.confirmable){
-      sender.send(buf, packet.ack || packet.reset || packet.confirmable === false)
-    } else {
-      debug('OMIT ACK PACKAGE')
-    }
-  })
+    return response
+  }
 
   request.rsinfo = rsinfo
-  response.statusCode = '2.05'
-  response._request = request._packet
-  response._cachekey = toCacheKey(rsinfo.address, rsinfo.port, packet)
 
-  var block2cache = this._block2Cache
-  //inject this function so the response can add an entry to the cache
-  response._addCacheEntry = function(key, payload) {
-    if (block2cache.hasOwnProperty(key)) {
-      debug('reuse old cache entry, key:', key)
-      clearTimeout(block2cache[key].timeoutId) // cancel old expiry timer
-      block2cache[key].payload = payload
-    } else {
-      debug('add payload to cache, key:', key)
-      block2cache[key] = {payload: payload}
-    }
-    // setup new expiry timer
-    block2cache[key].timeoutId = setTimeout(expiry, parameters.exchangeLifetime * 1000, block2cache, key)
-  }
+  response = generateResponse();
+  
 
   //return cached value for blockwise requests
   var cachedResponseSend = false
@@ -404,6 +417,52 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
         debug('found cached payload, key:', response._cachekey)
         response.end(this._block2Cache[response._cachekey].payload)
         cachedResponseSend = true
+      }
+    }
+  }
+  {
+    var block1Buff = getOption(response._request.options, 'Block1')
+    if(block1Buff) {
+      var blockState = parseBlockOption(block1Buff);
+
+      if(blockState) {
+        cachedResponseSend = blockState.moreBlocks;
+        response.code = "2.04";
+        response.setOption("Block1", block1Buff);
+
+        if (!this._block1Cache.hasOwnProperty(response._cachekey)) {
+          this._block1Cache[response._cachekey] = {};
+        }
+        var blockByteSize = Math.pow(2, 4+blockState.blockSize);
+        this._block1Cache[response._cachekey][blockState.sequenceNumber * blockByteSize] = request.payload;
+
+
+        if(!blockState.moreBlocks) {
+          var cachedData = this._block1Cache[response._cachekey];
+          var byteOffsets = Object.getOwnPropertyNames(cachedData);
+          var next = 0;
+          var concat = Buffer.alloc(blockState.sequenceNumber * blockByteSize + request.payload.length);
+          for(var i = 0; i < byteOffsets.length; i++) {
+            if(byteOffsets[i] == next) {
+              var buff = cachedData[byteOffsets[i]];
+              buff.copy(concat, next, 0, buff.length);
+              next += buff.length;
+            }
+          }
+          delete this._block1Cache[response._cachekey];
+          if(next == concat.length) {
+            request.payload = concat;
+            this.emit('request', request, response)
+          } else {
+            console.log("Got dupe packet");
+            throw new Error("Last byte index is not equal to the concat buffer length!");
+          }
+        } else {
+          response.end();
+        }
+        return
+      } else {
+        throw new Error("Invalid block state" + blockState);
       }
     }
   }
@@ -448,10 +507,11 @@ if (maxBlock2 > Math.pow(2, (6+4)))
 
 OutMessage.prototype.end= function(payload) {
   var that = this
-
+  
+  removeOption(this._request.options, 'Block1');  
   var block2Buff = getOption(this._request.options, 'Block2')
   var requestedBlockOption
-  // if we got blockwise (2) resquest
+  // if we got blockwise (2) request
   if (block2Buff) {
     requestedBlockOption = parseBlock2(block2Buff)
     // bad option


### PR DESCRIPTION
# Type-1 Block-wise transfer
Implementation of type-1 block-wise transfers. (Based on RFC7959)
Most of the logic has been implemented in 'segmentation.js'
This was implemented for testing purposes for another project, however may be useful for others too.
It has been tested against the Californium CoAP framework without any issue.
There's some examples in 'blockwise_put.js'

# DGRAM Socket closing prematurely
It seems that in rare circumstances, the CoAP agent is flagged to be closed, and whilst in the process of closing the DGRAM socket (between '_cleanUp' and '_doClose') there exists a small window where another CoAP request can be made.
Even if this request is made, the socket is still closed, and the response to the request is never received.
Resetting the '_closing' flag when a new request is made seems to solve the issue.