### PR TITLE
Fixes multiple responses to a non-confirmable multicast request

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -252,7 +252,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
   else if (block2) {
     delete that._tkToReq[req._packet.token.readUInt32BE(0)]
   }
-  else if (!req.url.observe && packet.token.length > 0) {
+  else if (!req.url.observe && packet.token.length > 0 && !req.multicast) {
     // it is not, so delete the token
     delete that._tkToReq[packet.token.readUInt32BE(0)]
   }
@@ -377,6 +377,7 @@ Agent.prototype.request = function request(url) {
   // Start multicast monitoring timer in case of multicast request
   if (url.multicast === true) {
     req.multicastTimer = setTimeout(function() {
+      delete that._tkToReq[req._packet.token.readUInt32BE(0)]
       that._msgInFlight--
       if (that._msgInFlight === 0) {
         that._doClose()

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -377,7 +377,9 @@ Agent.prototype.request = function request(url) {
   // Start multicast monitoring timer in case of multicast request
   if (url.multicast === true) {
     req.multicastTimer = setTimeout(function() {
-      delete that._tkToReq[req._packet.token.readUInt32BE(0)]
+      if (req._packet.token) {
+        delete that._tkToReq[req._packet.token.readUInt32BE(0)]
+      }
       that._msgInFlight--
       if (that._msgInFlight === 0) {
         that._doClose()


### PR DESCRIPTION
See issue #205.

The idea here is to remove the token-to-request mapped value after the multicast timer times out. Currently, the token is removed once the first response is handled, which prevents other responses from being handled.

Added a test with two servers handling a request. Each server responds with a different MID, thus the response is not mapped using the mid-to-requst map.