### PR TITLE
Fix more flag during block-wise transfer

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -183,7 +183,7 @@ create buffer for block2 option
 module.exports.createBlock2 = function createBlock2(requestedBlock) {
   var byte
   var szx = Math.log(requestedBlock.size)/Math.log(2) - 4
-  var m = ((requestedBlock.moreBlock2==true)?0:1)
+  var m = ((requestedBlock.moreBlock2==true)?1:0)
   var num = requestedBlock.num
   var extraNum
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -488,21 +488,17 @@ OutMessage.prototype.end= function(payload) {
     requestedBlockOption.size = maxBlock2
 
   // block number should have limit
-  // 0 base counter for totalBlock, hence use floor (vs ceil)
-  var totalBlock = Math.floor(payload.length/requestedBlockOption.size)
-  var isLastBlock
-  if (requestedBlockOption.num < totalBlock)
-    isLastBlock = false
-  else if (requestedBlockOption.num == totalBlock)
-    isLastBlock = true
-  else {
+  var lastBlockNum = Math.ceil(payload.length/requestedBlockOption.size) - 1
+  if (requestedBlockOption.num > lastBlockNum) {
     // precondition fail, may request for out of range block
     that.statusCode = '4.02'
     return OutgoingMessage.prototype.end.call(that)
   }
+  // check if requested block is the last
+  var moreFlag = requestedBlockOption.num < lastBlockNum
 
   var block2 = createBlock2({
-    moreBlock2: isLastBlock,
+    moreBlock2: moreFlag,
     num: requestedBlockOption.num,
     size: requestedBlockOption.size
   })

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -165,7 +165,6 @@ describe('blockwise2', function() {
         port: port
     })
     .setOption('Block2', Buffer.of(0x3D)) // request for block index 3
-
     .on('response', function(res) {
       expect(res.code).to.eql('4.02')
       //expect(cache.get(res._packet.token.toString())).to.be.undefined

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -19,7 +19,7 @@ describe('blockwise2', function() {
     , clientPort
     , client
     , bufferVal
-    , payload   = new Buffer(1536)
+    , payload   = Buffer.alloc(1536)
 
   beforeEach(function(done) {
     bufferVal = 0
@@ -164,7 +164,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x3D])) // request for block index 3
+    .setOption('Block2', Buffer.of(0x3D)) // request for block index 3
 
     .on('response', function(res) {
       expect(res.code).to.eql('4.02')

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -19,7 +19,7 @@ describe('blockwise2', function() {
     , clientPort
     , client
     , bufferVal
-    , payload   = new Buffer(1300)
+    , payload   = new Buffer(1536)
 
   beforeEach(function(done) {
     bufferVal = 0
@@ -158,10 +158,13 @@ describe('blockwise2', function() {
   })
 
   it('should receive error request for out of range block number', function(done) {
+    // with a block size of 512 and a total payload of 1536 there will be 3 blocks
+    // blocks are requested with a zero based index, i.e. indices 0, 1 and 2
+    // block index 3 or higher is "out of range" and should cause an error response
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x55])) // request for block 5, size = 512 from 1300B msg (total 1300/512=3 blocks)
+    .setOption('Block2', new Buffer([0x3D])) // request for block index 3
     .on('response', function(res) {
       expect(res.code).to.eql('4.02')
       //expect(cache.get(res._packet.token.toString())).to.be.undefined


### PR DESCRIPTION
If the payload was an exact multiple of the block size the index calculation was off by one.
This caused clients to make an additional redundant request at the end.
Also, GET requests would always have the more flag set, which was against the specs.