### PR TITLE
Upgrade Buffer api

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Example:
 
 or
 
-    message.setOption("555", [new Buffer('abcde'),new Buffer('ghi')]);
+    message.setOption("555", [Buffer.from('abcde'),Buffer.from('ghi')]);
 
 `setOption` is also aliased as `setHeader` for HTTP API
 compatibility.

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Also, `'Content-Type'` is aliased to `'Content-Format'` for HTTP
 compatibility.
 
 Since v0.7.0, this library supports blockwise transfers, you can trigger
-them by adding a `req.setOption('Block2', new Buffer([0x2]))` to the
+them by adding a `req.setOption('Block2', Buffer.of(0x2))` to the
 output of [request](#request).
 
 See the

--- a/examples/blockwise.js
+++ b/examples/blockwise.js
@@ -12,7 +12,7 @@ coap.createServer(function(req, res) {
   var req = coap.request('coap://localhost/repeat-me?t=400')
 
   // edit this to adjust max packet
-  req.setOption('Block2', new Buffer([0x2]))
+  req.setOption('Block2', Buffer.of(0x2))
 
   req.on('response', function(res) {
     res.pipe(process.stdout)

--- a/examples/delayed_response.js
+++ b/examples/delayed_response.js
@@ -3,7 +3,7 @@ const coap = require('../') // or coap
 coap.createServer(function(req, res) {
   //simulate delayed response
   setTimeout(function(){
-    res.setOption('Block2', new Buffer([2]));
+    res.setOption('Block2', Buffer.of(2));
     res.end('Hello ' + req.url.split('/')[1] + '\nMessage payload:\n'+req.payload+'\n')
   }, 1500)
 }).listen(function() {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -234,7 +234,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       // get full payload
       packet.payload = req._totalPayload
       // clear the payload incase of block2
-      req._totalPayload = new Buffer(0)
+      req._totalPayload = Buffer.alloc(0)
     }
   }
 
@@ -275,7 +275,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 }
 
 Agent.prototype._nextToken = function nextToken() {
-  var buf = new Buffer(4)
+  var buf = Buffer.alloc(4)
 
   if (++this._lastToken === maxToken)
     this._lastToken = 0
@@ -394,7 +394,7 @@ Agent.prototype.request = function request(url) {
 
   this._requests++
 
-  req._totalPayload = new Buffer(0)
+  req._totalPayload = Buffer.alloc(0)
 
   return req
 }
@@ -412,7 +412,7 @@ function urlPropertyToPacketOption(url, req, property, option, separator) {
     req.setOption(option, url[property].normalize('NFC').split(separator)
       .filter(function(part) { return part !== '' })
       .map(function(part) {
-        var buf = new Buffer(Buffer.byteLength(part))
+        var buf = Buffer.alloc(Buffer.byteLength(part))
         buf.write(part)
         return buf
       }))

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -178,7 +178,7 @@ module.exports.parseBlock2 = function parseBlock2(block2Value) {
 /*
 create buffer for block2 option
   requestedBlock      object contain block2 infor, e.g. {moreBlock2: true, num: 100, size: 32}
-  return              new Buffer, carry block2 value
+  return              Buffer carrying block2 value
 */
 module.exports.createBlock2 = function createBlock2(requestedBlock) {
   var byte
@@ -201,7 +201,7 @@ module.exports.createBlock2 = function createBlock2(requestedBlock) {
     extraNum = new Buffer([num/16])
   }
   else if (num <=0xfffff) {
-    extraNum = new Buffer(2)
+    extraNum = Buffer.alloc(2)
     extraNum.writeUInt16BE(num>>4,0)
   }
   else {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -198,7 +198,7 @@ module.exports.createBlock2 = function createBlock2(requestedBlock) {
     extraNum = null
   }
   else if (num <=0xfff) {
-    extraNum = new Buffer([num/16])
+    extraNum = Buffer.of(num/16)
   }
   else if (num <=0xfffff) {
     extraNum = Buffer.alloc(2)
@@ -208,7 +208,7 @@ module.exports.createBlock2 = function createBlock2(requestedBlock) {
     // too big block2 number
     return null
   }
-  return (extraNum)? Buffer.concat([extraNum, new Buffer([byte])]):new Buffer([byte])
+  return (extraNum)? Buffer.concat([extraNum, Buffer.of(byte)]):Buffer.of(byte)
 }
 
 /**

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -70,7 +70,7 @@ ObserveWriteStream.prototype.reset = function reset() {
   packet.payload = ''
   packet.reset = true;
   packet.ack = false
-  packet.token = new Buffer(0);
+  packet.token = Buffer.alloc(0);
 
   this._send(this, packet)
 

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -57,7 +57,7 @@ module.exports.isIgnored = function(name) {
 
 // ETag option registration
 var fromString = function(result) {
-  return new Buffer(result)
+  return Buffer.from(result)
 }
 
 var toString = function(value) {
@@ -79,7 +79,7 @@ var fromUint = function(result) {
     parts.unshift(uint % 256)
     uint = Math.floor(uint / 256)
   }
-  return new Buffer(parts)
+  return Buffer.from(parts)
 }
 
 var toUint = function(value) {

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -103,7 +103,7 @@ var registerFormat = function(name, value) {
     bytes = Buffer.alloc(2);
     bytes.writeUInt16BE(value, 0);
   } else {
-    bytes = new Buffer([value])
+    bytes = Buffer.of(value)
   }
 
   formatsString[name] = bytes
@@ -155,11 +155,11 @@ registerOption('Observe', function(sequence) {
   if (!sequence) {
     buf = Buffer.alloc(0)
   } else if (sequence <= 0xff) {
-    buf = Buffer.from([sequence])
+    buf = Buffer.of(sequence)
   } else if (sequence <= 0xffff) {
-    buf = Buffer.from([sequence >> 8, sequence])
+    buf = Buffer.of(sequence >> 8, sequence)
   } else {
-    buf = Buffer.from([sequence >> 16, sequence >> 8, sequence])
+    buf = Buffer.of(sequence >> 16, sequence >> 8, sequence)
   }
 
   return buf

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -100,7 +100,7 @@ var registerFormat = function(name, value) {
   var bytes;
 
   if (value > 255) {
-    bytes = new Buffer(2);
+    bytes = Buffer.alloc(2);
     bytes.writeUInt16BE(value, 0);
   } else {
     bytes = new Buffer([value])

--- a/lib/server.js
+++ b/lib/server.js
@@ -334,7 +334,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     Message = ObserveStream
     if (packet.code !== '0.01')
       // it is not a GET
-      return this._sendError(new Buffer('Observe can only be present with a GET'), rsinfo)
+      return this._sendError(Buffer.from('Observe can only be present with a GET'), rsinfo)
   }
 
   packet.piggybackReplyMs = this._options.piggybackReplyMs;

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,7 +37,7 @@ var dgram           = require('dgram')
 function handleEnding(err) {
   var request = this
   if (err) {
-    request.server._sendError(new Buffer(err.message), request.rsinfo, request.packet)
+    request.server._sendError(Buffer.from(err.message), request.rsinfo, request.packet)
   }
 }
 
@@ -529,7 +529,7 @@ use to generate etag
   id              return var, is a buffer(2)
 */
 function _toETag(payload) {
-  var id = new Buffer([0,0])
+  var id = Buffer.of(0, 0)
   var i = 0
   do {
     id[0] ^= payload[i]

--- a/test/agent.js
+++ b/test/agent.js
@@ -241,7 +241,7 @@ describe('Agent', function() {
           // Ensure the message sent by the server does not match any
           // current request.
           var invalidMid = packet.messageId + 1
-            , invalidTkn = new Buffer( packet.token )
+            , invalidTkn = Buffer.from(packet.token)
           ++invalidTkn[0]
 
           var toSend  = generate({

--- a/test/agent.js
+++ b/test/agent.js
@@ -123,7 +123,7 @@ describe('Agent', function() {
                       , token: packet.token
                       , code: '2.00'
                       , ack: true
-                      , payload: new Buffer(5)
+                      , payload: Buffer.alloc(5)
                     })
       
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -153,7 +153,7 @@ describe('Agent', function() {
             , token: packet.token
             , code: '2.00'
             , confirmable: false
-            , payload: new Buffer(5)
+            , payload: Buffer.alloc(5)
           })
       
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -182,7 +182,7 @@ describe('Agent', function() {
             , code: '2.00'
             , confirmable: false
             , ack: true
-            , payload: new Buffer(5)
+            , payload: Buffer.alloc(5)
           })
       
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -209,7 +209,7 @@ describe('Agent', function() {
             , code: '2.00'
             , confirmable: false
             , ack: true
-            , payload: new Buffer(5)
+            , payload: Buffer.alloc(5)
           })
       
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -250,7 +250,7 @@ describe('Agent', function() {
                 , code: '2.00'
                 , confirmable: true
                 , ack: false
-                , payload: new Buffer(5)
+                , payload: Buffer.alloc(5)
               })
           server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
           break
@@ -276,7 +276,7 @@ describe('Agent', function() {
             , code: '2.05'
             , confirmable: opts.confirmable
             , ack: opts.ack
-            , payload: new Buffer(5)
+            , payload: Buffer.alloc(5)
             , options: [{
                   name: 'Observe'
                 , value: new Buffer([opts.num])

--- a/test/agent.js
+++ b/test/agent.js
@@ -279,7 +279,7 @@ describe('Agent', function() {
             , payload: Buffer.alloc(5)
             , options: [{
                   name: 'Observe'
-                , value: new Buffer([opts.num])
+                , value: Buffer.of(opts.num)
               }]
           })
       

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -121,7 +121,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x02]))
+    .setOption('Block2', Buffer.of(0x02))
     .on('response', function(res) {
       var block2
       for (var i in res.options) {
@@ -145,7 +145,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x07])) // request for block 0, with overload size of 2**(7+4)
+    .setOption('Block2', Buffer.of(0x07)) // request for block 0, with overload size of 2**(7+4)
     .on('response', function(res) {
       expect(res.code).to.eql('4.02')
       //expect(cache.get(res._packet.token.toString())).to.be.undefined
@@ -161,7 +161,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x55])) // request for block 5, size = 512 from 1300B msg (total 1300/512=3 blocks)
+    .setOption('Block2', Buffer.of(0x55)) // request for block 5, size = 512 from 1300B msg (total 1300/512=3 blocks)
     .on('response', function(res) {
       expect(res.code).to.eql('4.02')
       //expect(cache.get(res._packet.token.toString())).to.be.undefined
@@ -177,7 +177,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x10])) // request from block 1, with size = 16
+    .setOption('Block2', Buffer.of(0x10)) // request from block 1, with size = 16
     .on('response', function(res) {
       expect(res.payload).to.eql(payload.slice(1*16, payload.length+1))
       //expect(cache.get(res._packet.token.toString())).to.not.be.undefined
@@ -194,7 +194,7 @@ describe('blockwise2', function() {
     var req = coap.request({
         port: port
     })
-    .setOption('Block2', new Buffer([0x0])) // early negotation with block size = 16, almost 10000/16 = 63 blocks
+    .setOption('Block2', Buffer.of(0x0)) // early negotation with block size = 16, almost 10000/16 = 63 blocks
     .on('response', function(res) {
       expect(res.payload).to.eql(payload)
       //expect(cache.get(res._packet.token.toString())).to.not.be.undefined
@@ -212,7 +212,7 @@ describe('blockwise2', function() {
       , token: req_token
       , options: [{
             name: 'Block2'
-          , value: new Buffer([req_block2_num << 4])
+          , value: Buffer.of(req_block2_num << 4)
         }]
     }
     send(generate(packet))
@@ -270,7 +270,7 @@ describe('blockwise2', function() {
         }
     })
 
-    req_client2.setOption('Block2', new Buffer([0x10])) // request from block 1, with size = 16
+    req_client2.setOption('Block2', Buffer.of(0x10)) // request from block 1, with size = 16
 
     // Delay second request so that first request gets first packet
     setTimeout(function() {

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -19,7 +19,7 @@ describe('blockwise2', function() {
     , clientPort
     , client
     , bufferVal
-    , payload   = new Buffer(1300)
+    , payload   = Buffer.alloc(1300)
 
   beforeEach(function(done) {
     bufferVal = 0
@@ -57,7 +57,7 @@ describe('blockwise2', function() {
   }
 
   it('should server not use blockwise in response when payload fit in one packet', function(done) {
-    var payload   = new Buffer(100)         // default max packet is 1280
+    var payload   = Buffer.alloc(100)         // default max packet is 1280
 
     var req = coap.request({
         port: port
@@ -222,7 +222,7 @@ describe('blockwise2', function() {
     var payload_len = 32+16+1
     var payload_req1 = new Buffer(payload_len)
     var payload_req2 = new Buffer(payload_len)
-    var req1_token = new Buffer(4)
+    var req1_token = Buffer.alloc(4)
     var req1_done = false
     var req2_done = false
     var req1_block2_num = 0

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -190,7 +190,7 @@ describe('blockwise2', function() {
   })
 
   it('should receive full response payload', function(done) {
-    var payload = new Buffer(16*0xff+1)
+    var payload = Buffer.alloc(16*0xff+1)
     var req = coap.request({
         port: port
     })
@@ -220,8 +220,8 @@ describe('blockwise2', function() {
 
   function parallelBlock2Test(done, checkNReq, checkBlock2Message, checkNormalReq) {
     var payload_len = 32+16+1
-    var payload_req1 = new Buffer(payload_len)
-    var payload_req2 = new Buffer(payload_len)
+    var payload_req1 = Buffer.alloc(payload_len)
+    var payload_req2 = Buffer.alloc(payload_len)
     var req1_token = Buffer.alloc(4)
     var req1_done = false
     var req2_done = false

--- a/test/ipv6.js
+++ b/test/ipv6.js
@@ -68,14 +68,14 @@ describe('IPv6', function() {
     function createTest(createUrl) {
       return function (done) {
         var req = coap.request(createUrl())
-        req.end(new Buffer('hello world'))
+        req.end(Buffer.from('hello world'))
 
         server.on('message', function(msg, rsinfo) {
           var packet = parse(msg)
             , toSend = generate({
                            messageId: packet.messageId
                          , token: packet.token
-                         , payload: new Buffer('42')
+                         , payload: Buffer.from('42')
                          , ack: true
                          , code: '2.00'
                        })

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -84,7 +84,7 @@ describe('proxy', function() {
     send(generate({
       options: [{
         name: 'Proxy-Uri'
-        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+        , value: Buffer.from('coap://localhost:' + targetPort + '/the/path')
       }]
     }))
 
@@ -142,7 +142,7 @@ describe('proxy', function() {
     send(generate({
       options: [{
         name: 'Proxy-Uri'
-        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+        , value: Buffer.from('coap://localhost:' + targetPort + '/the/path')
       }]
     }))
   })
@@ -151,7 +151,7 @@ describe('proxy', function() {
     send(generate({
       options: [{
         name: 'Proxy-Uri'
-        , value: new Buffer('coap://localhost:' + targetPort + '/the/path')
+        , value: Buffer.from('coap://localhost:' + targetPort + '/the/path')
       }]
     }))
 

--- a/test/request.js
+++ b/test/request.js
@@ -68,7 +68,7 @@ describe('request', function() {
 
   it('should send the data to the server', function (done) {
     var req = request('coap://localhost:' + port)
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
@@ -79,7 +79,7 @@ describe('request', function() {
 
   it('should send a confirmable message by default', function (done) {
     var req = request('coap://localhost:' + port)
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
@@ -96,7 +96,7 @@ describe('request', function() {
       done()
     })
 
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
   })
 
   it('should error if the message is too big', function (done) {
@@ -124,14 +124,14 @@ describe('request', function() {
 
   it('should send the path to the server', function (done) {
     var req = request('coap://localhost:' + port + '/hello')
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
       expect(packet.options[0].name).to.eql('Uri-Path')
-      expect(packet.options[0].value).to.eql(new Buffer('hello'))
+      expect(packet.options[0].value).to.eql(Buffer.from('hello'))
 
       done()
     })
@@ -139,16 +139,16 @@ describe('request', function() {
 
   it('should send a longer path to the server', function (done) {
     var req = request('coap://localhost:' + port + '/hello/world')
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
       expect(packet.options[0].name).to.eql('Uri-Path')
-      expect(packet.options[0].value).to.eql(new Buffer('hello'))
+      expect(packet.options[0].value).to.eql(Buffer.from('hello'))
       expect(packet.options[1].name).to.eql('Uri-Path')
-      expect(packet.options[1].value).to.eql(new Buffer('world'))
+      expect(packet.options[1].value).to.eql(Buffer.from('world'))
       done()
     })
   })
@@ -160,32 +160,32 @@ describe('request', function() {
       , pathname: '/hello/world'
     })
 
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
       expect(packet.options[0].name).to.eql('Uri-Path')
-      expect(packet.options[0].value).to.eql(new Buffer('hello'))
+      expect(packet.options[0].value).to.eql(Buffer.from('hello'))
       expect(packet.options[1].name).to.eql('Uri-Path')
-      expect(packet.options[1].value).to.eql(new Buffer('world'))
+      expect(packet.options[1].value).to.eql(Buffer.from('world'))
       done()
     })
   })
 
   it('should send a query string to the server', function (done) {
     var req = request('coap://localhost:' + port + '?a=b&c=d')
-    req.end(new Buffer('hello world'))
+    req.end(Buffer.from('hello world'))
 
     server.on('message', function (msg, rsinfo) {
       ackBack(msg, rsinfo)
 
       var packet = parse(msg)
       expect(packet.options[0].name).to.eql('Uri-Query')
-      expect(packet.options[0].value).to.eql(new Buffer('a=b'))
+      expect(packet.options[0].value).to.eql(Buffer.from('a=b'))
       expect(packet.options[1].name).to.eql('Uri-Query')
-      expect(packet.options[1].value).to.eql(new Buffer('c=d'))
+      expect(packet.options[1].value).to.eql(Buffer.from('c=d'))
       done()
     })
   })
@@ -216,7 +216,7 @@ describe('request', function() {
         , toSend = generate({
           messageId: packet.messageId
           , token: packet.token
-          , payload: new Buffer('42')
+          , payload: Buffer.from('42')
           , ack: true
           , code: '2.00'
         })
@@ -225,7 +225,7 @@ describe('request', function() {
 
     req.on('response', function (res) {
       res.pipe(bl(function (err, data) {
-        expect(data).to.eql(new Buffer('42'))
+        expect(data).to.eql(Buffer.from('42'))
         done()
       }))
     })
@@ -244,7 +244,7 @@ describe('request', function() {
         , toSend = generate({
           messageId: packet.messageId
           , token: packet.token
-          , payload: new Buffer('')
+          , payload: Buffer.alloc(0)
           , ack: true
           , code: '0.00'
         })
@@ -252,7 +252,7 @@ describe('request', function() {
 
       toSend = generate({
         token: packet.token
-        , payload: new Buffer('42')
+        , payload: Buffer.from('42')
         , confirmable: true
         , code: '2.00'
       })
@@ -261,7 +261,7 @@ describe('request', function() {
 
     req.on('response', function (res) {
       res.pipe(bl(function (err, data) {
-        expect(data).to.eql(new Buffer('42'))
+        expect(data).to.eql(Buffer.from('42'))
         done()
       }))
     })
@@ -287,7 +287,7 @@ describe('request', function() {
 
       toSend = generate({
         token: packet.token
-        , payload: new Buffer('42')
+        , payload: Buffer.from('42')
         , confirmable: true
         , code: '2.00'
       })
@@ -338,7 +338,7 @@ describe('request', function() {
         , toSend = generate({
           messageId: packet.messageId
           , token: packet.token
-          , payload: new Buffer('42')
+          , payload: Buffer.from('42')
           , code: '2.00'
         })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -346,7 +346,7 @@ describe('request', function() {
 
     req.on('response', function (res) {
       res.pipe(bl(function (err, data) {
-        expect(data).to.eql(new Buffer('42'))
+        expect(data).to.eql(Buffer.from('42'))
         done()
       }))
     })
@@ -553,7 +553,7 @@ describe('request', function() {
         , toSend = generate({
           token: packet.token
           , messageId: packet.messageId
-          , payload: new Buffer('42')
+          , payload: Buffer.from('42')
           , confirmable: true
           , code: '2.00'
         })
@@ -562,7 +562,7 @@ describe('request', function() {
       toSend = generate({
         token: packet.token
         , messageId: packet.messageId
-        , payload: new Buffer('42')
+        , payload: Buffer.from('42')
         , confirmable: true
         , code: '2.00'
       })
@@ -571,7 +571,7 @@ describe('request', function() {
 
     req.on('response', function (res) {
       res.pipe(bl(function (err, data) {
-        expect(data).to.eql(new Buffer('42'))
+        expect(data).to.eql(Buffer.from('42'))
         done()
       }))
     })
@@ -701,7 +701,7 @@ describe('request', function() {
           , token: packet.token
           , options: [{
             name: 'ETag'
-            , value: new Buffer('abcdefgh')
+            , value: Buffer.from('abcdefgh')
           }]
         })
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -966,7 +966,7 @@ describe('request', function() {
         ssend(rsinfo, {
           messageId: packet.messageId
           , token: packet.token
-          , payload: new Buffer('42')
+          , payload: Buffer.from('42')
           , ack: true
           , options: [{
             name: 'Observe'
@@ -977,7 +977,7 @@ describe('request', function() {
 
         ssend(rsinfo, {
           token: packet.token
-          , payload: new Buffer('24')
+          , payload: Buffer.from('24')
           , confirmable: true
           , options: [{
             name: 'Observe'
@@ -1348,7 +1348,7 @@ describe('request', function() {
         var toSend = generate({
           messageId: packet.messageId
           , token: packet.token
-          , payload: new Buffer('42')
+          , payload: Buffer.from('42')
           , ack: true
           , code: '2.00'
         })

--- a/test/request.js
+++ b/test/request.js
@@ -106,7 +106,7 @@ describe('request', function() {
       done()
     })
 
-    req.end(new Buffer(1280))
+    req.end(Buffer.alloc(1280))
   })
 
   it('should imply a default port', function (done) {
@@ -451,7 +451,7 @@ describe('request', function() {
     var req = request({
         port: port
       })
-      , buf = new Buffer(3)
+      , buf = Buffer.alloc(3)
 
     req.setOption('ETag', buf)
     req.end()
@@ -467,7 +467,7 @@ describe('request', function() {
     var req = request({
         port: port
       })
-      , buf = new Buffer(3)
+      , buf = Buffer.alloc(3)
 
     req.setOption('content-type', buf)
     req.end()
@@ -483,9 +483,9 @@ describe('request', function() {
     var req = request({
         port: port
       })
-      , buf = new Buffer(3)
+      , buf = Buffer.alloc(3)
 
-    req.setOption('ETag', new Buffer(3))
+    req.setOption('ETag', Buffer.alloc(3))
     req.setOption('ETag', buf)
     req.end()
 
@@ -499,7 +499,7 @@ describe('request', function() {
     var req = request({
         port: port
       })
-      , buf = new Buffer(3)
+      , buf = Buffer.alloc(3)
 
     req.setHeader('ETag', buf)
     req.end()
@@ -514,8 +514,8 @@ describe('request', function() {
     var req = request({
         port: port
       })
-      , buf1 = new Buffer(3)
-      , buf2 = new Buffer(3)
+      , buf1 = Buffer.alloc(3)
+      , buf2 = Buffer.alloc(3)
 
     req.setOption('433', [buf1, buf2])
     req.end()
@@ -825,7 +825,7 @@ describe('request', function() {
             , token: packet.token
             , code: '2.00'
             , ack: true
-            , payload: new Buffer(5)
+            , payload: Buffer.alloc(5)
           })
 
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -1081,7 +1081,7 @@ describe('request', function() {
       server.on('message', function (msg, rsinfo) {
         var packet = parse(msg)
         expect(packet.options[0].name).to.eql('Observe')
-        expect(packet.options[0].value).to.eql(new Buffer(0))
+        expect(packet.options[0].value).to.eql(Buffer.alloc(0))
         done()
       })
     })
@@ -1251,7 +1251,7 @@ describe('request', function() {
         var packet = parse(msg)
           , toSend = generate({
             messageId: packet.messageId
-            , token: new Buffer(2)
+            , token: Buffer.alloc(2)
             , options: []
           })
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
@@ -1279,7 +1279,7 @@ describe('request', function() {
         var packet = parse(msg)
           , toSend = generate({
             messageId: packet.messageId
-            , token: new Buffer(4)
+            , token: Buffer.alloc(4)
             , options: []
           })
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)

--- a/test/request.js
+++ b/test/request.js
@@ -532,12 +532,12 @@ describe('request', function() {
       port: port
     })
 
-    req.setOption('Content-Type', new Buffer([0]))
+    req.setOption('Content-Type', Buffer.of(0))
     req.end()
 
     server.on('message', function (msg) {
       expect(parse(msg).options[0].name).to.eql('Content-Format')
-      expect(parse(msg).options[0].value).to.eql(new Buffer([0]))
+      expect(parse(msg).options[0].value).to.eql(Buffer.of(0))
       done()
     })
   })
@@ -580,13 +580,13 @@ describe('request', function() {
   })
 
   var formatsString = {
-    'text/plain': new Buffer([0])
-    , 'application/link-format': new Buffer([40])
-    , 'application/xml': new Buffer([41])
-    , 'application/octet-stream': new Buffer([42])
-    , 'application/exi': new Buffer([47])
-    , 'application/json': new Buffer([50])
-    , 'application/cbor': new Buffer([60])
+    'text/plain': Buffer.of(0)
+    , 'application/link-format': Buffer.of(40)
+    , 'application/xml': Buffer.of(41)
+    , 'application/octet-stream': Buffer.of(42)
+    , 'application/exi': Buffer.of(47)
+    , 'application/json': Buffer.of(50)
+    , 'application/cbor': Buffer.of(60)
   }
 
   describe('with the \'Content-Format\' header in the outgoing message', function () {
@@ -970,7 +970,7 @@ describe('request', function() {
           , ack: true
           , options: [{
             name: 'Observe'
-            , value: new Buffer([1])
+            , value: Buffer.of(1)
           }]
           , code: '2.05'
         })
@@ -981,7 +981,7 @@ describe('request', function() {
           , confirmable: true
           , options: [{
             name: 'Observe'
-            , value: new Buffer([2])
+            , value: Buffer.of(2)
           }]
           , code: '2.05'
         })

--- a/test/server.js
+++ b/test/server.js
@@ -112,7 +112,7 @@ describe('server', function() {
   })
 
   it('should receive a request that can be piped', function(done) {
-    var buf = new Buffer(25)
+    var buf = Buffer.alloc(25)
     send(generate({ payload: buf }))
     server.on('request', function(req, res) {
       req.pipe(bl(function(err, data) {
@@ -123,7 +123,7 @@ describe('server', function() {
   })
 
   it('should expose the payload', function(done) {
-    var buf = new Buffer(25)
+    var buf = Buffer.alloc(25)
     send(generate({ payload: buf }))
     server.on('request', function(req, res) {
       expect(req.payload).to.eql(buf)
@@ -132,7 +132,7 @@ describe('server', function() {
   })
 
   it('should include an URL in the request', function(done) {
-    var buf = new Buffer(25)
+    var buf = Buffer.alloc(25)
     send(generate({ payload: buf }))
     server.on('request', function(req, res) {
       expect(req).to.have.property('url', '/')
@@ -141,7 +141,7 @@ describe('server', function() {
   })
 
   it('should include the code', function(done) {
-    var buf = new Buffer(25)
+    var buf = Buffer.alloc(25)
     send(generate({ payload: buf }))
     server.on('request', function(req, res) {
       expect(req).to.have.property('code', '0.01')
@@ -230,7 +230,7 @@ describe('server', function() {
   it('should expose the options', function(done) {
     var options = [{
         name: '555'
-      , value: new Buffer(45)
+      , value: Buffer.alloc(45)
     }]
 
     send(generate({
@@ -244,8 +244,8 @@ describe('server', function() {
   })
 
   it('should include a reset() function in the response', function(done) {
-    var buf = new Buffer(25)
-    var tok = new Buffer(4)
+    var buf = Buffer.alloc(25)
+    var tok = Buffer.alloc(4)
     send(generate({ payload: buf, token: tok }))
     client.on('message', function(msg, rinfo) {
       var result = parse(msg)
@@ -351,7 +351,7 @@ describe('server', function() {
     var packet = {
         confirmable: false
       , messageId: 4242
-      , token: new Buffer(5)
+      , token: Buffer.alloc(5)
     }
 
     function sendAndRespond(status) {
@@ -406,7 +406,7 @@ describe('server', function() {
     })
 
     it('should allow to add an option', function(done) {
-      var buf = new Buffer(3)
+      var buf = Buffer.alloc(3)
 
       send(generate(packet))
 
@@ -423,12 +423,12 @@ describe('server', function() {
     })
 
     it('should overwrite the option', function(done) {
-      var buf = new Buffer(3)
+      var buf = Buffer.alloc(3)
 
       send(generate(packet))
 
       server.on('request', function(req, res) {
-        res.setOption('ETag', new Buffer(3))
+        res.setOption('ETag', Buffer.alloc(3))
         res.setOption('ETag', buf)
         res.end('42')
       })
@@ -455,8 +455,8 @@ describe('server', function() {
     })
 
     it('should set multiple options', function(done) {
-      var buf1 = new Buffer(3)
-        , buf2 = new Buffer(3)
+      var buf1 = Buffer.alloc(3)
+        , buf2 = Buffer.alloc(3)
 
       send(generate(packet))
 
@@ -539,7 +539,7 @@ describe('server', function() {
     })
 
     it('should reply with a \'5.00\' if it cannot parse the packet', function(done) {
-      send(new Buffer(3))
+      send(Buffer.alloc(3))
       client.on('message', function(msg) {
         expect(parse(msg).code).to.eql('5.00')
         done()
@@ -571,7 +571,7 @@ describe('server', function() {
     var packet = {
         confirmable: true
       , messageId: 4242
-      , token: new Buffer(5)
+      , token: Buffer.alloc(5)
     }
 
     it('should reply in piggyback', function(done) {
@@ -597,7 +597,7 @@ describe('server', function() {
         expect(response.ack).to.be.true
         expect(response.code).to.eql('0.00')
         expect(response.messageId).to.eql(packet.messageId)
-        expect(response.payload).to.eql(new Buffer(0))
+        expect(response.payload).to.eql(Buffer.alloc(0))
         done()
       })
 
@@ -742,7 +742,7 @@ describe('server', function() {
   })
 
   describe('observe', function() {
-    var token = new Buffer(3)
+    var token = Buffer.alloc(3)
 
     function doObserve(method) {
       if (!method)
@@ -754,7 +754,7 @@ describe('server', function() {
         , token: token
         , options: [{
               name: 'Observe'
-            , value: new Buffer(0)
+            , value: Buffer.alloc(0)
           }]
       }))
     }
@@ -1001,7 +1001,7 @@ describe('validate custom server options', function() {
     client.on('message', function(msg) {
       messages++
     })
-    send(new Buffer(3))
+    send(Buffer.alloc(3))
     setTimeout(function() {
       expect(messages).to.eql(1)
       expect(server._options.piggybackReplyMs).to.eql(piggyBackTimeout)
@@ -1050,7 +1050,7 @@ describe('validate custom server options', function() {
     var packet = {
         confirmable: false
       , messageId: 4242
-      , token: new Buffer(5)
+      , token: Buffer.alloc(5)
     }
     send(generate(packet))
   }
@@ -1059,7 +1059,7 @@ describe('validate custom server options', function() {
     var packet = {
         confirmable: true
       , messageId: 4242
-      , token: new Buffer(5)
+      , token: Buffer.alloc(5)
     }
     send(generate(packet))
   }
@@ -1120,7 +1120,7 @@ describe('server LRU', function() {
   var packet = {
     confirmable: true
     , messageId: 4242
-    , token: new Buffer(5)
+    , token: Buffer.alloc(5)
   }
 
   beforeEach(function (done) {

--- a/test/server.js
+++ b/test/server.js
@@ -174,10 +174,10 @@ describe('server', function() {
     send(generate({
         options: [{
             name: 'Uri-Path'
-          , value: new Buffer('hello')
+          , value: Buffer.from('hello')
         }, {
             name: 'Uri-Path'
-          , value: new Buffer('world')
+          , value: Buffer.from('world')
         }]
     }))
 
@@ -191,10 +191,10 @@ describe('server', function() {
     send(generate({
         options: [{
             name: 'Uri-Query'
-          , value: new Buffer('a=b')
+          , value: Buffer.from('a=b')
         }, {
             name: 'Uri-Query'
-          , value: new Buffer('b=c')
+          , value: Buffer.from('b=c')
         }]
     }))
 
@@ -208,16 +208,16 @@ describe('server', function() {
     send(generate({
         options: [{
             name: 'Uri-Query'
-          , value: new Buffer('a=b')
+          , value: Buffer.from('a=b')
         }, {
             name: 'Uri-Query'
-          , value: new Buffer('b=c')
+          , value: Buffer.from('b=c')
         }, {
             name: 'Uri-Path'
-          , value: new Buffer('hello')
+          , value: Buffer.from('hello')
         }, {
             name: 'Uri-Path'
-          , value: new Buffer('world')
+          , value: Buffer.from('world')
         }]
     }))
 
@@ -368,7 +368,7 @@ describe('server', function() {
     it('should reply with a payload to a NON message', function(done) {
       sendAndRespond()
       client.on('message', function(msg) {
-        expect(parse(msg).payload).to.eql(new Buffer('42'))
+        expect(parse(msg).payload).to.eql(Buffer.from('42'))
         done()
       })
     })
@@ -449,7 +449,7 @@ describe('server', function() {
 
       client.on('message', function(msg) {
         expect(parse(msg).options[0].name).to.eql('ETag')
-        expect(parse(msg).options[0].value).to.eql(new Buffer('hello world'))
+        expect(parse(msg).options[0].value).to.eql(Buffer.from('hello world'))
         done()
       })
     })
@@ -518,7 +518,7 @@ describe('server', function() {
 
       client.on('message', function(msg, rsinfo) {
         expect(parse(msg).options[0].name).to.eql('ETag')
-        expect(parse(msg).options[0].value).to.eql(new Buffer('abcdefgh'))
+        expect(parse(msg).options[0].value).to.eql(Buffer.from('abcdefgh'))
         done()
       })
     })
@@ -584,7 +584,7 @@ describe('server', function() {
         var response = parse(msg)
         expect(response.ack).to.be.true
         expect(response.messageId).to.eql(packet.messageId)
-        expect(response.payload).to.eql(new Buffer('42'))
+        expect(response.payload).to.eql(Buffer.from('42'))
         done()
       })
     })

--- a/test/server.js
+++ b/test/server.js
@@ -277,13 +277,13 @@ describe('server', function() {
   })
 
   var formatsString = {
-      'text/plain': new Buffer([0])
-    , 'application/link-format': new Buffer([40])
-    , 'application/xml': new Buffer([41])
-    , 'application/octet-stream': new Buffer([42])
-    , 'application/exi': new Buffer([47])
-    , 'application/json': new Buffer([50])
-    , 'application/cbor': new Buffer([60])
+      'text/plain': Buffer.of(0)
+    , 'application/link-format': Buffer.of(40)
+    , 'application/xml': Buffer.of(41)
+    , 'application/octet-stream': Buffer.of(42)
+    , 'application/exi': Buffer.of(47)
+    , 'application/json': Buffer.of(50)
+    , 'application/cbor': Buffer.of(60)
   }
 
   describe('with the \'Content-Format\' header in the request', function() {
@@ -328,7 +328,7 @@ describe('server', function() {
       send(generate({
         options: [{
           name: 'Content-Format'
-          , value: new Buffer([1541])
+          , value: Buffer.of(1541)
         }]
       }))
 
@@ -533,7 +533,7 @@ describe('server', function() {
 
       client.on('message', function(msg, rsinfo) {
         expect(parse(msg).options[0].name).to.eql('Content-Format')
-        expect(parse(msg).options[0].value).to.eql(new Buffer([0]))
+        expect(parse(msg).options[0].value).to.eql(Buffer.of(0))
         done()
       })
     })
@@ -808,7 +808,7 @@ describe('server', function() {
       client.once('message', function(msg) {
         expect(parse(msg).payload.toString()).to.eql('hello')
         expect(parse(msg).options[0].name).to.eql('Observe')
-        expect(parse(msg).options[0].value).to.eql(new Buffer([1]))
+        expect(parse(msg).options[0].value).to.eql(Buffer.of(1))
         expect(parse(msg).token).to.eql(token)
         expect(parse(msg).code).to.eql('2.05')
         expect(parse(msg).ack).to.be.true
@@ -816,7 +816,7 @@ describe('server', function() {
         client.once('message', function(msg) {
           expect(parse(msg).payload.toString()).to.eql('world')
           expect(parse(msg).options[0].name).to.eql('Observe')
-          expect(parse(msg).options[0].value).to.eql(new Buffer([2]))
+          expect(parse(msg).options[0].value).to.eql(Buffer.of(2))
           expect(parse(msg).token).to.eql(token)
           expect(parse(msg).code).to.eql('2.05')
           expect(parse(msg).ack).to.be.false
@@ -904,10 +904,10 @@ describe('server', function() {
 
       // the first one is an ack
       client.once('message', function(msg) {
-        expect(parse(msg).options[0].value).to.eql(Buffer.from([0x10, 0x93]))
+        expect(parse(msg).options[0].value).to.eql(Buffer.of(0x10, 0x93))
 
         client.once('message', function(msg) {
-          expect(parse(msg).options[0].value).to.eql(Buffer.from([0x10, 0x94]))
+          expect(parse(msg).options[0].value).to.eql(Buffer.of(0x10, 0x94))
           done()
         })
       })
@@ -930,10 +930,10 @@ describe('server', function() {
 
       // the first one is an ack
       client.once('message', function(msg) {
-        expect(parse(msg).options[0].value).to.eql(Buffer.from([1, 0, 0]))
+        expect(parse(msg).options[0].value).to.eql(Buffer.of(1, 0, 0))
 
         client.once('message', function(msg) {
-          expect(parse(msg).options[0].value).to.eql(Buffer.from([1, 0, 1]))
+          expect(parse(msg).options[0].value).to.eql(Buffer.of(1, 0, 1))
           done()
         })
       })


### PR DESCRIPTION
This fixes warnings because of deprecated `Buffer` api, see here: https://nodejs.org/fr/docs/guides/buffer-constructor-deprecation/