### PR TITLE
Add support for de-registering observations

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -380,10 +380,14 @@ Agent.prototype.request = function request(url) {
     var token
     if (!(packet.ack || packet.reset)) {
       packet.messageId = that._nextMessageId()
-      if (url.token instanceof Buffer)
+      if ((url.token instanceof Buffer) && (url.token.length > 0)) {
+        if (url.token.length > 8) {
+          return req.emit('error', new Error('Token may be no longer than 8 bytes.'));
+        }
         packet.token = url.token;
-      else
+      } else {
         packet.token = that._nextToken()
+      }
       packet.token = that._nextToken()
       token = packet.token.toString('hex')
       that._tkToMulticastResAddr[token] = []

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -9,6 +9,7 @@
  */
 
 var util                  = require('util')
+  , crypto                = require('crypto')
   , events                = require('events')
   , dgram                 = require('dgram')
   , parse                 = require('coap-packet').parse
@@ -333,12 +334,13 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 }
 
 Agent.prototype._nextToken = function nextToken() {
-  var buf = Buffer.alloc(4)
+  var buf = Buffer.alloc(8)
 
   if (++this._lastToken === maxToken)
     this._lastToken = 0
 
   buf.writeUInt32BE(this._lastToken, 0)
+  crypto.randomBytes(4).copy(buf, 4)
 
   return buf;
 }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -315,6 +315,16 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       }
       that._cleanUp()
     })
+    response.on('deregister', function() {
+      var deregister_url = Object.assign({}, req.url);
+      deregister_url.observe = 1;
+      deregister_url.token = req._packet.token;
+
+      let deregister_req = that.request(deregister_url);
+      // If the request fails, we'll deal with it with a RST message anyway.
+      deregister_req.on('error', function() {});
+      deregister_req.end();
+    })
   } else {
     response = new IncomingMessage(packet, rsinfo, outSocket)
   }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -380,6 +380,10 @@ Agent.prototype.request = function request(url) {
     var token
     if (!(packet.ack || packet.reset)) {
       packet.messageId = that._nextMessageId()
+      if (url.token instanceof Buffer)
+        packet.token = url.token;
+      else
+        packet.token = that._nextToken()
       packet.token = that._nextToken()
       token = packet.token.toString('hex')
       that._tkToMulticastResAddr[token] = []

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -148,8 +148,8 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
         }
       }
   if (!req) {
-    if (packet.token && packet.token.length === 4) {
-      req = this._tkToReq[packet.token.readUInt32BE(0)]
+    if (packet.token.length > 0) {
+      req = this._tkToReq[packet.token.toString('hex')]
     }
 
     if ((packet.ack || packet.reset) && !req) {
@@ -298,21 +298,17 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 
   }
   else if (block2) {
-    if (req._packet.token.length >= 4) {
-      delete that._tkToReq[req._packet.token.readUInt32BE(0)]
-    }
+    delete that._tkToReq[req._packet.token.toString('hex')]
   }
-  else if (!req.url.observe && packet.token.length >= 4 && !req.multicast) {
+  else if (!req.url.observe && !req.multicast) {
     // it is not, so delete the token
-    delete that._tkToReq[packet.token.readUInt32BE(0)]
+    delete that._tkToReq[packet.token.toString('hex')]
   }
 
   if (req.url.observe && packet.code !== '4.04') {
     response = new ObserveStream(packet, rsinfo, outSocket)
     response.on('close', function() {
-      if (packet.token.length >= 4) {
-        delete that._tkToReq[packet.token.readUInt32BE(0)]
-      }
+      delete that._tkToReq[packet.token.toString('hex')]
       that._cleanUp()
     })
     response.on('deregister', function() {
@@ -381,17 +377,21 @@ Agent.prototype.request = function request(url) {
       packet.confirmable = false
     }
 
+    var token
     if (!(packet.ack || packet.reset)) {
       packet.messageId = that._nextMessageId()
       packet.token = that._nextToken()
-      that._tkToMulticastResAddr[that._lastToken] = []
+      token = packet.token.toString('hex')
+      that._tkToMulticastResAddr[token] = []
       if (req.multicast) {
-        that._tkToMulticastResAddr[that._lastToken] = []
+        that._tkToMulticastResAddr[token] = []
       }
     }
 
     that._msgIdToReq[packet.messageId] = req
-    that._tkToReq[that._lastToken] = req
+    if (token) {
+      that._tkToReq[token] = req
+    }
 
     var block1Buff = getOption(packet.options, 'Block1')
     if(block1Buff) {
@@ -453,9 +453,10 @@ Agent.prototype.request = function request(url) {
   // Start multicast monitoring timer in case of multicast request
   if (url.multicast === true) {
     req.multicastTimer = setTimeout(function() {
-      if (req._packet.token && req._packet.token.length >= 4) {
-        delete that._tkToReq[req._packet.token.readUInt32BE(0)]
-        delete that._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)]
+      if (req._packet.token) {
+        var token = req._packet.token.toString('hex')
+        delete that._tkToReq[token]
+        delete that._tkToMulticastResAddr[token]
       }
       delete that._msgIdToReq[req._packet.messageId]
       that._msgInFlight--
@@ -484,8 +485,8 @@ Agent.prototype.abort = function (req) {
   req.sender.reset()
   this._cleanUp()
   delete this._msgIdToReq[req._packet.messageId]
-  if (req._packet.token && req._packet.token.length >= 4) {
-    delete this._tkToReq[req._packet.token.readUInt32BE(0)]
+  if (req._packet.token) {
+    delete this._tkToReq[req._packet.token.toString('hex')]
   }
 }
 
@@ -503,8 +504,8 @@ function urlPropertyToPacketOption(url, req, property, option, separator) {
 Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {
   var unicastReq = this.request(req.url)
   var unicastAddress = rsinfo.address.split('%')[0]
-
-  if (this._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)].includes(unicastAddress)) {
+  var token = req._packet.token.toString('hex')
+  if (this._tkToMulticastResAddr[token].includes(unicastAddress)) {
     return null
   }
 
@@ -517,7 +518,7 @@ Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {
       unicastReq.on(eventName, listener)
     })
   })
-  this._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)].push(unicastAddress)
+  this._tkToMulticastResAddr[token].push(unicastAddress)
   unicastReq._packet.token = this._nextToken()
   this._requests++
   return unicastReq

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -388,7 +388,6 @@ Agent.prototype.request = function request(url) {
       } else {
         packet.token = that._nextToken()
       }
-      packet.token = that._nextToken()
       token = packet.token.toString('hex')
       that._tkToMulticastResAddr[token] = []
       if (req.multicast) {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -455,7 +455,9 @@ Agent.prototype.request = function request(url) {
     }, multicastTimeout)
   }
 
-  if (url.observe)
+  if (typeof (url.observe) === "number")
+    req.setOption('Observe', url.observe)
+  else if (url.observe)
     req.setOption('Observe', null)
   else
     req.on('response', this._cleanUp.bind(this))

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -47,9 +47,12 @@ ObserveReadStream.prototype.append = function(packet) {
   }
 }
 
-ObserveReadStream.prototype.close = function() {
+ObserveReadStream.prototype.close = function(eagerDeregister) {
   this.push(null)
   this.emit('close')
+  if (eagerDeregister) {
+    this.emit('deregister');
+  }
 }
 
 // nothing to do, data will be pushed from the server

--- a/lib/server.js
+++ b/lib/server.js
@@ -228,18 +228,27 @@ CoAPServer.prototype.listen = function(port, address, done) {
     this._sock = dgram.createSocket({type: this._options.type, reuseAddr : true})
 
     this._sock.bind(port, address || null, function () {
-      if (that._multicastAddress) {
-        that._sock.setMulticastLoopback(true)
+      try {
+        if (that._multicastAddress) {
+          that._sock.setMulticastLoopback(true)
 
-        if (that._multicastInterface) {
-          that._sock.addMembership(that._multicastAddress, that._multicastInterface)
-        } else {
-          allAddresses(that._options.type).forEach(function(_interface) {
+          if (that._multicastInterface) {
+            that._sock.addMembership(that._multicastAddress, that._multicastInterface)
+          } else {
+            allAddresses(that._options.type).forEach(function(_interface) {
               that._sock.addMembership(that._multicastAddress, _interface)
-          })
+            })
+          }
         }
+      } catch (err) {
+        if (done)
+          return done(err)
+        else
+          throw err;
       }
-      if (done) done()
+
+      if (done)
+        return done()
     })
   }
 

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -205,6 +205,7 @@ describe('proxy', function() {
 
   describe('with a proxied request with a wrong destination', function() {
     it('should return an error to the caller', function(done) {
+      this.timeout(20000);
       var request = coap.request({
         host: 'localhost',
         port: port,
@@ -221,8 +222,12 @@ describe('proxy', function() {
 
       request
           .on('response', function(res) {
-            expect(res.code).to.eql('5.00');
-            expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/);
+            try {
+              expect(res.code).to.eql('5.00');
+              expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/);
+            } catch (err) {
+              return done(err);
+            }
             done()
           })
           .end()

--- a/test/request.js
+++ b/test/request.js
@@ -1087,6 +1087,25 @@ describe('request', function() {
       })
     })
 
+    it('should allow user to send Observe=1', function (done) {
+      var req = request({
+        port: port
+        , observe: 1
+      }).end()
+
+      server.on('message', function (msg, rsinfo) {
+        var packet = parse(msg)
+        try {
+          expect(packet.options[0].name).to.eql('Observe')
+          expect(packet.options[0].value).to.eql(Buffer.from([1]))
+        } catch (err) {
+          return done(err);
+        }
+
+        done()
+      })
+    })
+
     it('should allow multiple notifications', function (done) {
       server.once('message', function(msg, rsinfo) {
         const req = parse(msg)

--- a/test/request.js
+++ b/test/request.js
@@ -227,7 +227,7 @@ describe('request', function() {
   })
 
   it('should reject too long token', function (done) {
-    let rq = request({
+    var rq = request({
       port: port
       , token: Buffer.from([1,2,3,4,5,6,7,8,9,10])
     });

--- a/test/request.js
+++ b/test/request.js
@@ -1073,6 +1073,25 @@ describe('request', function() {
       })
     })
 
+    it('should send deregister request if close(eager=true)', function (done) {
+
+      var req = doObserve()
+
+      req.on('response', function (res) {
+        res.once('data', function (data) {
+          expect(data.toString()).to.eql('42')
+          res.close(true)
+
+          server.on('message', function (msg, rsinfo) {
+            var packet = parse(msg)
+            expect(packet.options[0].name).to.eql('Observe')
+            expect(packet.options[0].value).to.eql(Buffer.from([1]))
+            done()
+          })
+        })
+      })
+    })
+
     it('should send an empty Observe option', function (done) {
       var req = request({
         port: port

--- a/test/request.js
+++ b/test/request.js
@@ -1124,8 +1124,16 @@ describe('request', function() {
 
           server.on('message', function (msg, rsinfo) {
             var packet = parse(msg)
-            expect(packet.options[0].name).to.eql('Observe')
-            expect(packet.options[0].value).to.eql(Buffer.from([1]))
+            if (packet.ack && (packet.code === '0.00'))
+              return;
+
+            try {
+              expect(packet.options.length).to.be.least(1);
+              expect(packet.options[0].name).to.eql('Observe')
+              expect(packet.options[0].value).to.eql(Buffer.from([1]))
+            } catch (err) {
+              return done(err);
+            }
             done()
           })
         })

--- a/test/request.js
+++ b/test/request.js
@@ -214,11 +214,15 @@ describe('request', function() {
     }).end()
 
     server.on('message', function (msg, rsinfo) {
-      ackBack(msg, rsinfo)
+      try {
+        ackBack(msg, rsinfo)
 
-      var packet = parse(msg)
-      expect(packet.token).to.eql(Buffer.from([1,2,3,4,5,6,7,8]))
-      done()
+        var packet = parse(msg)
+        expect(packet.token).to.eql(Buffer.from([1,2,3,4,5,6,7,8]))
+        done();
+      } catch (err) {
+        done(err);
+      }
     })
   })
 

--- a/test/request.js
+++ b/test/request.js
@@ -90,6 +90,7 @@ describe('request', function() {
   })
 
   it('should emit the errors in the req', function (done) {
+    this.timeout(20000);
     var req = request('coap://aaa.eee:' + 1234)
 
     req.once('error', function () {

--- a/test/request.js
+++ b/test/request.js
@@ -226,6 +226,25 @@ describe('request', function() {
     })
   })
 
+  it('should ignore empty token parameter', function (done) {
+    request({
+      port: port
+      , token: Buffer.from([])
+    }).end()
+
+    server.on('message', function (msg, rsinfo) {
+      try {
+        ackBack(msg, rsinfo)
+
+        var packet = parse(msg)
+        expect(packet.token.length).to.be.above(0)
+        done();
+      } catch (err) {
+        done(err);
+      }
+    })
+  })
+
   it('should reject too long token', function (done) {
     var rq = request({
       port: port

--- a/test/server.js
+++ b/test/server.js
@@ -654,8 +654,12 @@ describe('server', function() {
       })
 
       setTimeout(function() {
-        // original one plus 4 retries
-        expect(messages).to.eql(5)
+        try {
+          // original one plus 4 retries
+          expect(messages).to.eql(5)
+        } catch (err) {
+          return done(err);
+        }
         done()
       }, 45 * 1000)
 


### PR DESCRIPTION
This is a superset of pull request #164, bringing forward and building on the work of @pekkanikander.  Since this alone didn't go all the way to solving issue #195, I also bit the bullet and implemented that too.

Due to the commit hooks set up on this repository, I was forced to fix a few other issues as part of this pull request, notably the "leaking" of exceptions by some callback functions, as well as extending the time-outs on some unhappy path tests that were failing simply because some network operations were taking a bit longer to signal an error.

Finally, since it's required for RFC-7641, I have added the ability for a user to specify their own token, that way when de-registering, we can honour the spec and send the correct token to the CoAP server.

Since the de-registration would _not_ have a token matching `_lastToken` anymore, it was necessary to tweak how requests were matched against their tokens: we now convert the token to `hex` representation, which has the bonus of removing the 4-byte hard limit on token lengths present before.

I have tested this implementation against the [OpenThread CoAP server](https://github.com/openthread/openthread/pull/4396), and it seems to perform as expected.