### PR TITLE
handle errors coming from underlying Datagram socket send call

### DIFF
--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -42,14 +42,18 @@ util.inherits(RetrySend, EventEmitter)
 RetrySend.prototype._send = function(avoidBackoff) {
   var that = this
 
-  this._sock.send(this._message, 0, this._message.length,
+  try{
+    this._sock.send(this._message, 0, this._message.length,
                   this._port, this._host, function(err, bytes) {
                     that.emit('sent', err, bytes)
                     if (err) {
                       that.emit('error', err)
                     }
                   })
-
+  }
+  catch(e){
+    that.emit('error', e.message)
+  }
   var messageId = parse(this._message).messageId
   if (messageId != this._lastMessageId) {
     this._lastMessageId = messageId


### PR DESCRIPTION
Currently, exceptions coming from retry_send (e.g. socket closed) are not being propagated to upper layers.