### PR TITLE
Fix handling of block2 reponses to multicast requests

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -206,6 +206,11 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
     }
   }
   if (block2) {
+
+    if (req.multicast) {
+      req = this._convertMulticastToUnicastRequest(req, rsinfo)
+    } 
+
     // accumulate payload
     req._totalPayload = Buffer.concat([req._totalPayload, packet.payload])
 
@@ -384,8 +389,9 @@ Agent.prototype.request = function request(url) {
       if (req._packet.token && req._packet.token.length >= 4) {
         delete that._tkToReq[req._packet.token.readUInt32BE(0)]
       }
+      delete that._msgIdToReq[req._packet.messageId]
       that._msgInFlight--
-      if (that._msgInFlight === 0) {
+      if (that._msgInFlight === 0 && that._closing) {
         that._doClose()
       }
     }, multicastTimeout)
@@ -422,6 +428,16 @@ function urlPropertyToPacketOption(url, req, property, option, separator) {
         buf.write(part)
         return buf
       }))
+}
+
+Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {  
+  var unicastReq = this.request(req.url)
+  unicastReq.url.host, unicastReq.sender._host = rsinfo.address.split('%')[0]
+  unicastReq.url.multicast = false;
+  req.listeners("response").forEach(listener => {
+    unicastReq.on("response", listener)
+  });
+  return unicastReq
 }
 
 module.exports = Agent

--- a/test/request.js
+++ b/test/request.js
@@ -1398,7 +1398,37 @@ describe('request', function() {
       }).end()
     })
 
-  })
+    it('should allow for block-wise transfer when using multicast', function (done) {
+      var payload = Buffer.alloc(1536)
+        , counter = 0  
+      
+      server = coap.createServer((req, res) => {
+        expect(req.url).to.eql("/hello")
+        res.end(payload)
+      })
+      server.listen(sock)
+      
+      var server2 = coap.createServer((req, res) => {
+        expect(req.url).to.eql("/hello")
+        res.end(payload)
+      })
+      server2.listen(sock)
 
+      var _req = request({
+        host: MULTICAST_ADDR,
+        port: port2,
+        pathname: "/hello",
+        confirmable: false,
+        multicast: true,
+      }).on('response', function (res) {
+        expect(res.payload.toString()).to.eql(payload.toString())
+        counter++
+        if (counter == 2) {
+          done()
+        }
+      }).end()
+    })
+
+  })
 
 })


### PR DESCRIPTION
This PR offers a potential fix for #236. As mentioned in the issue (and suggested by [RFC 7959](https://tools.ietf.org/rfcmarkup/7959#section-2.8)), the agent now switches to unicast requests if a response containing a block2 option is given to a multicast request. 

This solves a problem that occured if two servers offering providing the same resource path are reachable over the same multicast address leading to confusion in the agent as the same block numbers are requested over and over again from the multicast address once a new reponse arrives.

This PR is still a bit WIP as the new `_convertMulticastToUnicastRequest` function could probably be refactored if there is a more elegant way to perform a deep copy of the initial request. I am also still working on corresponding unit tests. However, I performed a lot of manually testing/debugging which makes me confident that the solution should already work. In any case, feedback is highly appreciated :)