### PR TITLE
chore: move CI to Github Actions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,0 +1,38 @@
+name: Build Status
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        os: [ubuntu-latest, windows-latest] # FIXME: Tests on macos-latest fail at the moment
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Perform tests and generate coverage report
+      run: |
+        npm test
+        npm run coverage
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-sudo: false
-dist: trusty
-before_script: sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-node_js:
-  - "10"
-  - "12"
-  - "14"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 node-coap
 =====
 
-[![Build
-Status](https://travis-ci.org/mcollina/node-coap.png)](https://travis-ci.org/mcollina/node-coap)
+![Build Status](https://github.com/mcollina/node-coap/workflows/Build%20Status/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/mcollina/node-coap/badge.svg?branch=master)](https://coveralls.io/github/mcollina/node-coap?branch=master)
 [![gitter](https://badges.gitter.im/mcollina/node-coap.png)](https://gitter.im/mcollina/node-coap)
 
 __node-coap__ is a client and server library for CoAP modeled after the `http` module.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "A CoAP library for node modelled after 'http'",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --bail",
-    "testnobail": "./node_modules/.bin/mocha",
-    "test-cov": "nyc npm run test"
+    "test": "nyc mocha --exit",
+    "coverage": "nyc report --reporter=lcov --reporter=text-summary"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR will resolve #224. Tests are now performed on Node versions 10.x, 12.x, 14.x, 15.x, and on multiple platforms (Ubuntu, Windows, Mac OS). One test on Mac OS, however, fails at the moment. This problem should either be fixed or Mac OS should be skipped for testing for now.

The CI pipeline now also generates a coverage report and supports `coveralls` which can be used for including a badge in the readme. I also thought about including a linting step using JSHint or ESLint but I guess this would require some configuration due to the used coding style.