### PR TITLE
fix: copy all listeners when using block2 multicast

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -434,9 +434,11 @@ Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {
   var unicastReq = this.request(req.url)
   unicastReq.url.host, unicastReq.sender._host = rsinfo.address.split('%')[0]
   unicastReq.url.multicast = false;
-  req.listeners("response").forEach(listener => {
-    unicastReq.on("response", listener)
-  });
+  req.eventNames().forEach(eventName => {
+    req.listeners(eventName).forEach(listener => {
+      unicastReq.on(eventName, listener)
+    })
+  })
   return unicastReq
 }
 

--- a/test/request.js
+++ b/test/request.js
@@ -1428,6 +1428,40 @@ describe('request', function() {
         }
       }).end()
     })
+    
+    it('should preserve all listeners when using block-wise transfer and multicast', function (done) {
+      var payload = Buffer.alloc(1536)
+        , counter = 0  
+      
+      server = coap.createServer((req, res) => {
+        res.end(payload)
+      })
+      server.listen(sock)
+      
+      var server2 = coap.createServer((req, res) => {
+        res.end(payload)
+      })
+      server2.listen(sock)
+
+      var _req = request({
+        host: MULTICAST_ADDR,
+        port: port2,
+        confirmable: false,
+        multicast: true,
+      })
+
+      _req.on("bestEventEver", function () {
+        counter++
+        if (counter == 2) {
+          done()
+        }
+      })
+      
+      _req.on('response', function (res) {
+        expect(res.payload.toString()).to.eql(payload.toString())
+        _req.emit("bestEventEver")
+      }).end()
+    })
 
   })
 


### PR DESCRIPTION
This PR fixes a small bug that was included in #237 by "copying" not only the listeners for `response` events but for all events registered to a multicast request when converting it to a unicast request. Copying only `reponse` listeners could lead, for example, to unhandled `error` events causing an application to crash.