### PR TITLE
Fix three more problems with blockwise multicast responses

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -97,6 +97,7 @@ Agent.prototype._init = function initSock(socket) {
 
   this._msgIdToReq = {}
   this._tkToReq = {}
+  this._tkToMulticastResAddr = {}
 
   this._lastToken = Math.floor(Math.random() * (maxToken - 1))
   this._lastMessageId = Math.floor(Math.random() * (maxMessageId - 1))
@@ -209,7 +210,10 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
 
     if (req.multicast) {
       req = this._convertMulticastToUnicastRequest(req, rsinfo)
-    } 
+      if (!req) {
+        return
+      }
+    }
 
     // accumulate payload
     req._totalPayload = Buffer.concat([req._totalPayload, packet.payload])
@@ -327,6 +331,10 @@ Agent.prototype.request = function request(url) {
     if (!(packet.ack || packet.reset)) {
       packet.messageId = that._nextMessageId()
       packet.token = that._nextToken()
+      that._tkToMulticastResAddr[that._lastToken] = []
+      if (req.multicast) {
+        that._tkToMulticastResAddr[that._lastToken] = []
+      }
     }
 
     try {
@@ -388,6 +396,7 @@ Agent.prototype.request = function request(url) {
     req.multicastTimer = setTimeout(function() {
       if (req._packet.token && req._packet.token.length >= 4) {
         delete that._tkToReq[req._packet.token.readUInt32BE(0)]
+        delete that._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)]
       }
       delete that._msgIdToReq[req._packet.messageId]
       that._msgInFlight--
@@ -430,15 +439,26 @@ function urlPropertyToPacketOption(url, req, property, option, separator) {
       }))
 }
 
-Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {  
+Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {
   var unicastReq = this.request(req.url)
-  unicastReq.url.host, unicastReq.sender._host = rsinfo.address.split('%')[0]
+  var unicastAddress = rsinfo.address.split('%')[0]
+
+  if (this._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)].includes(unicastAddress)) {
+    return null
+  }
+
+  unicastReq.url.host = unicastAddress
+  unicastReq.sender._host = unicastAddress
+  clearTimeout(unicastReq.multicastTimer)
   unicastReq.url.multicast = false;
   req.eventNames().forEach(eventName => {
     req.listeners(eventName).forEach(listener => {
       unicastReq.on(eventName, listener)
     })
   })
+  this._tkToMulticastResAddr[req._packet.token.readUInt32BE(0)].push(unicastAddress)
+  unicastReq._packet.token = this._nextToken()
+  this._requests++
   return unicastReq
 }
 

--- a/test/request.js
+++ b/test/request.js
@@ -1444,6 +1444,38 @@ describe('request', function() {
       }).end()
     })
 
+    it('should ignore multiple responses from the same hostname when using block2 multicast', function (done) {
+      var payload = Buffer.alloc(1536)
+
+      var counter = 0
+      
+      server = coap.createServer((req, res) => {
+        res.end(payload)
+      })
+      server.listen(sock)
+
+      var server2 = coap.createServer((req, res) => {
+        res.end(payload)
+      })
+      server2.listen(sock)
+
+      var _req = request({
+        host: MULTICAST_ADDR,
+        port: port2,
+        confirmable: false,
+        multicast: true,
+      }).on('response', function (res) {
+        counter++        
+      }).end()
+      
+      setTimeout(function () {
+        expect(counter).to.eql(1)
+        done()
+      }, 45 * 1000)
+
+      fastForward(100, 45 * 1000)
+    })
+
   })
 
 })

--- a/test/request.js
+++ b/test/request.js
@@ -1400,19 +1400,12 @@ describe('request', function() {
 
     it('should allow for block-wise transfer when using multicast', function (done) {
       var payload = Buffer.alloc(1536)
-        , counter = 0  
       
       server = coap.createServer((req, res) => {
         expect(req.url).to.eql("/hello")
         res.end(payload)
       })
       server.listen(sock)
-      
-      var server2 = coap.createServer((req, res) => {
-        expect(req.url).to.eql("/hello")
-        res.end(payload)
-      })
-      server2.listen(sock)
 
       var _req = request({
         host: MULTICAST_ADDR,
@@ -1422,26 +1415,17 @@ describe('request', function() {
         multicast: true,
       }).on('response', function (res) {
         expect(res.payload.toString()).to.eql(payload.toString())
-        counter++
-        if (counter == 2) {
-          done()
-        }
+        done()
       }).end()
     })
     
     it('should preserve all listeners when using block-wise transfer and multicast', function (done) {
       var payload = Buffer.alloc(1536)
-        , counter = 0  
       
       server = coap.createServer((req, res) => {
         res.end(payload)
       })
       server.listen(sock)
-      
-      var server2 = coap.createServer((req, res) => {
-        res.end(payload)
-      })
-      server2.listen(sock)
 
       var _req = request({
         host: MULTICAST_ADDR,
@@ -1451,10 +1435,7 @@ describe('request', function() {
       })
 
       _req.on("bestEventEver", function () {
-        counter++
-        if (counter == 2) {
-          done()
-        }
+        done()
       })
       
       _req.on('response', function (res) {


### PR DESCRIPTION
I noticed three more (and hopefully last) problems with block-wise transfer and multicast requests which are addressed by this PR. 

First, I noticed that when performing a multicast request nodes could reply multiple times leading to more messages than required and, more importantly, duplicated payloads which could lead to unintended behavior. I fixed this problem by keeping track of the hostnames of the respondants that replied to the inital multicast request. If a server replies twice to a multicast, all reponses after the first one will be ignored. 

A second fix addresses the fact that the multicast timer from the initial request got reinitialized in the converted unicast request causing the client to abort the transfer once the time limit was reached. Using `clearTimeout()`, this timer now gets removed.

Third, new tokens are now assigned to the created unicast requests. Before, no new token was created which lead to issues when more than one server was responding to the multicast. A final minor change is the now correct assignment of the unicast IP address to the new request's `url.host` field (which should have little to no impact, though).

Because of the changes to the way "duplicated" IP addresses are handled, I had to adjust the two test cases I added in #237 and #242. Despite the fact that now only one server is left I think the core functionality is still tested as the single server is responding to the multicast in a blockwise manner despite switching from multicast to unicast.

Sorry that this is yet another PR on essentially the same issue. However, I think now I found a solution that should work, so hopefully no more PRs on this will be needed :)