### PR TITLE
Add linter for StandardJS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: StandardJS Linter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    # Caches NPM and the node_modules folder for faster builds
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Use linter
+      run: npm run lint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha --exit",
-    "coverage": "nyc report --reporter=lcov --reporter=text-summary"
+    "coverage": "nyc report --reporter=lcov --reporter=text-summary",
+    "lint": "standard --verbose | snazzy",
+    "lint:fix": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -33,6 +35,8 @@
     "nyc": "^15.1.0",
     "pre-commit": "1.2.2",
     "sinon": "^9.0.2",
+    "snazzy": "^9.0.0",
+    "standard": "^16.0.1",
     "timekeeper": "^1.0.0"
   },
   "dependencies": {
@@ -43,5 +47,8 @@
     "fastseries": "^2.0.0",
     "lru-cache": "^5.1.1",
     "readable-stream": "^3.6.0"
+  },
+  "standard": {
+    "env": ["jest"]
   }
 }


### PR DESCRIPTION
This PR adds a linter for Standard JS to both the CI pipeline and the `package.json` file.

It does not include any fixes yet as there are almost 4000 issues in the code but the linter already gives feedback to newly added code under the changes tab which should be handy. Follow-up PRs should address issues in the code one-by-one and gradually move the codebase towards StandardJS compliance. 