### PR TITLE
Add version info on type 1 block-wise transfers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Since v0.7.0, this library supports blockwise transfers, you can trigger
 them by adding a `req.setOption('Block2', Buffer.of(0x2))` to the
 output of [request](#request).
 
-And since v?.?.?, this library supports rudimentry type 1 blockwise transfers, you can trigger
+And since v0.25.0, this library supports rudimentry type 1 blockwise transfers, you can trigger
 them by adding a `req.setOption('Block1', new Buffer([0x2]))` to the
 options of [request](#request).
 


### PR DESCRIPTION
This PR updates the README in accordance to the newly added feature for type 1 block-wise transfer. I created a PR for this change as I wanted to be sure that this actually going to be a new *minor* release.