### PR TITLE
docs: fix ObserveWriteStream interfaces in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Each new `write()` call is a __new message__ being sent to the client.
 
 It implements the [Writable
 Stream](http://nodejs.org/api/stream.html#stream_class_stream_writable)
-and [OutgoingMessage](#outgoing) interfaces, as well as the
+interface, as well as the
 following additional methods and properties.
 
 #### Event: 'finish'


### PR DESCRIPTION
Let the README reflect that `ObserveWriteStream` does not actually implement the  `OutgoingMessage` interface.

Merging this PR will make PR #177 obsolete (for now at least).