### PR TITLE
feat: add more content-formats

### DIFF
--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -112,13 +112,36 @@ var registerFormat = function(name, value) {
 
 module.exports.registerFormat = registerFormat
 
+// See https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
+// for a list of all registered content-formats
 registerFormat('text/plain', 0)
 registerFormat('application/link-format', 40)
 registerFormat('application/xml', 41)
 registerFormat('application/octet-stream', 42)
 registerFormat('application/exi', 47)
 registerFormat('application/json', 50)
+registerFormat('application/json-patch+json', 51)
+registerFormat('application/merge-patch+json', 52)
 registerFormat('application/cbor', 60)
+registerFormat('application/cwt', 61)
+registerFormat('application/multipart-core', 62)
+registerFormat('application/cbor-seq', 63)
+registerFormat('application/cose-key', 101)
+registerFormat('application/cose-key-set', 102)
+registerFormat('application/senml+json', 110)
+registerFormat('application/sensml+json', 111)
+registerFormat('application/senml+cbor', 112)
+registerFormat('application/sensml+cbor', 113)
+registerFormat('application/senml-exi', 114)
+registerFormat('application/sensml-exi', 115)
+registerFormat('application/coap-group+json', 256)
+registerFormat('application/dots+cbor', 271)
+registerFormat('application/missing-blocks+cbor-seq', 272)
+registerFormat('application/senml+xml', 310)
+registerFormat('application/sensml+xml', 311)
+registerFormat('application/senml-etch+json', 320)
+registerFormat('application/senml-etch+cbor', 322)
+registerFormat('application/td+json', 432)
 
 var contentFormatToBinary = function(value) {
   var result = formatsString[value.split(';')[0]]


### PR DESCRIPTION
This PR adds more content-formats the library that are available by default. There are still codes that could be added, see [this IANA page](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats) for the full list of available CoAP content-formats.

I am not sure about the current way the formats are registered. Maybe it makes more sense to define them as an array somewhere and then iterate over them at startup?