### PR TITLE
Update copyright information

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright (c) 2013-2015 node-coap contributors
+Copyright (c) 2013-2021 node-coap contributors
 ----------------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/block.js
+++ b/lib/block.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/incoming_message.js
+++ b/lib/incoming_message.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
-* Copyright (c) 2013-2015 node-coap contributors.
+* Copyright (c) 2013-2021 node-coap contributors.
 *
 * node-coap is licensed under an MIT +no-false-attribs license.
 * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,5 +1,13 @@
 'use strict';
 
+/*
+* Copyright (c) 2013-2021 node-coap contributors.
+*
+* node-coap is licensed under an MIT +no-false-attribs license.
+* All rights not explicitly granted in the MIT license are reserved.
+* See the included LICENSE file for more details.
+*/
+
 exports.compareBuffers = function (buf1, buf2) {
   if (Buffer.compare)
     return Buffer.compare(buf1, buf2)

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,3 +1,13 @@
+'use strict';
+
+/*
+ * Copyright (c) 2013-2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 var generate           = require('coap-packet').generate
  , generateBlockOption = require('./block').generateBlockOption
  , exponentToByteSize  = require('./block').exponentToByteSize;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/agent.js
+++ b/test/agent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/common.js
+++ b/test/common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/ipv6.js
+++ b/test/ipv6.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/request.js
+++ b/test/request.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/retry_send.js
+++ b/test/retry_send.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/segmentation.js
+++ b/test/segmentation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.

--- a/test/share-socket.js
+++ b/test/share-socket.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 node-coap contributors.
+ * Copyright (c) 2013-2021 node-coap contributors.
  *
  * node-coap is licensed under an MIT +no-false-attribs license.
  * All rights not explicitly granted in the MIT license are reserved.


### PR DESCRIPTION
This PR updates the copyright information to "2013-2021" and adds a license header to two newly added files that didn't have one before.