### PR TITLE
style: remove obsolete semicolons

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,40 @@
+name: StandardJS Linter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Caches NPM and the node_modules folder for faster builds
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Use linter
+      run: npx eslint .
+

--- a/examples/blockwise_put.js
+++ b/examples/blockwise_put.js
@@ -49,10 +49,10 @@ function TestPut () {
       console.log(req.payload.slice(0, containedData.length*2).toString('utf-8'))
       console.log(req.payload.slice(-containedData.length).toString('utf-8'))
       console.log("Sending back pleasantries")
-      res.statusCode = "2.04";
+      res.statusCode = "2.04"
       res.end("Congratulations!")
       console.log("Sent back")
-    }, 500);
+    }, 500)
   }).listen(function () {
     var request = coap.request({
       hostname: this.hostname,
@@ -78,13 +78,13 @@ function TestPut () {
 */
 function TestServer () {
   coap.createServer(function (req, res) {
-    console.log("Got request. Waiting 500ms");
+    console.log("Got request. Waiting 500ms")
     setTimeout(() => {
         res.setOption('Block2', new Buffer([0x6]))
         console.log("Sending Back Test Buffer")
         res.end(testBuffer)
         console.log("Sent Back")
-    }, 500);
+    }, 500)
   }).listen()
 }
 

--- a/examples/delayed_response.js
+++ b/examples/delayed_response.js
@@ -3,7 +3,7 @@ const coap = require('../') // or coap
 coap.createServer(function(req, res) {
   //simulate delayed response
   setTimeout(function(){
-    res.setOption('Block2', Buffer.of(2));
+    res.setOption('Block2', Buffer.of(2))
     res.end('Hello ' + req.url.split('/')[1] + '\nMessage payload:\n'+req.payload+'\n')
   }, 1500)
 }).listen(function() {

--- a/examples/multicast_client_server.js
+++ b/examples/multicast_client_server.js
@@ -20,14 +20,14 @@ server.on('request', function(msg, res) {
 	console.log('Server 1 has received message')
 	res.end('Ok')
 
-	server.close();
+	server.close()
 })
 
 server2.on('request', function(msg, res) {
 	console.log('Server 2 has received message')
 	res.end('Ok')
 
-	server2.close();
+	server2.close()
 })
 
 // Send multicast message

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -2,42 +2,42 @@ const
     coap = require('../'),
     async = require('async'),
     Readable = require('stream').Readable,
-    requestNumber = 10;
+    requestNumber = 10
 
 var targetServer,
     proxy,
     client1,
     client2,
-    targetResults;
+    targetResults
 
 function formatTitle(msg) {
-    return '\n\n' + msg + '\n-------------------------------------';
+    return '\n\n' + msg + '\n-------------------------------------'
 }
 
 function requestHandler(req, res) {
-    console.log('Target receives [%s] in port [8976] from port [%s]', req.payload, req.rsinfo.port);
-    res.end('RES_' + req.payload);
+    console.log('Target receives [%s] in port [8976] from port [%s]', req.payload, req.rsinfo.port)
+    res.end('RES_' + req.payload)
 }
 
 function createTargetServer(callback) {
-    console.log('Creating target server at port 8976');
+    console.log('Creating target server at port 8976')
 
-    targetServer = coap.createServer(requestHandler);
+    targetServer = coap.createServer(requestHandler)
 
-    targetServer.listen(8976, '0.0.0.0', callback);
+    targetServer.listen(8976, '0.0.0.0', callback)
 }
 
 function proxyHandler(req, res) {
-    console.log('Proxy handled [%s]', req.payload);
-    res.end('RES_' + req.payload);
+    console.log('Proxy handled [%s]', req.payload)
+    res.end('RES_' + req.payload)
 }
 
 function createProxy(callback) {
-    console.log('Creating proxy at port 6780');
+    console.log('Creating proxy at port 6780')
 
-    proxy = coap.createServer({ proxy: true }, proxyHandler);
+    proxy = coap.createServer({ proxy: true }, proxyHandler)
 
-    proxy.listen(6780, '0.0.0.0', callback);
+    proxy.listen(6780, '0.0.0.0', callback)
 }
 
 function sendRequest(proxied) {
@@ -47,46 +47,46 @@ function sendRequest(proxied) {
                 port: 8976,
                 agent: false
             },
-            rs = new Readable();
+            rs = new Readable()
 
         if (proxied) {
-            req.port = 6780;
-            req.proxyUri = 'coap://localhost:8976';
+            req.port = 6780
+            req.proxyUri = 'coap://localhost:8976'
         }
 
-        request = coap.request(req);
+        request = coap.request(req)
 
         request.on('response', function(res) {
-            console.log('Client receives [%s] in port [%s] from [%s]', res.payload, res.outSocket.port, res.rsinfo.port);
-            callback();
-        });
+            console.log('Client receives [%s] in port [%s] from [%s]', res.payload, res.outSocket.port, res.rsinfo.port)
+            callback()
+        })
 
-        rs.push('MSG_' + n);
-        rs.push(null);
-        rs.pipe(request);
+        rs.push('MSG_' + n)
+        rs.push(null)
+        rs.pipe(request)
     }
 }
 
 function executeTest(proxied) {
     return function(callback) {
         if (proxied) {
-            console.log(formatTitle('Executing tests with proxy'));
+            console.log(formatTitle('Executing tests with proxy'))
         } else {
-            console.log(formatTitle('Executing tests without proxy'));
+            console.log(formatTitle('Executing tests without proxy'))
         }
 
-        async.times(requestNumber, sendRequest(proxied), callback);
+        async.times(requestNumber, sendRequest(proxied), callback)
     }
 }
 
 function cleanUp(callback) {
     targetServer.close(function () {
-        proxy.close(callback);
-    });
+        proxy.close(callback)
+    })
 }
 
 function checkResults(callback) {
-    console.log(formatTitle('Finish'));
+    console.log(formatTitle('Finish'))
 }
 
 async.series([
@@ -95,4 +95,4 @@ async.series([
     executeTest(false),
     executeTest(true),
     cleanUp
-], checkResults);
+], checkResults)

--- a/examples/req_with_payload.js
+++ b/examples/req_with_payload.js
@@ -11,7 +11,7 @@ coap.createServer(function(req, res) {
     body: 'containing nothing useful'
   }
   
-  req.write(JSON.stringify(payload));
+  req.write(JSON.stringify(payload))
   
   req.on('response', function(res) {
     res.pipe(process.stdout)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
  *

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -61,7 +61,7 @@ util.inherits(Agent, events.EventEmitter)
 
 Agent.prototype._init = function initSock(socket) {
   
-  this._closing = false;
+  this._closing = false
   
   if (this._sock) {
     return
@@ -84,12 +84,12 @@ Agent.prototype._init = function initSock(socket) {
       return
     }
 
-    outSocket = that._sock.address();
+    outSocket = that._sock.address()
     that._handle(msg, rsinfo, outSocket)
   })
 
   if(this._opts.port) {
-    this._sock.bind( this._opts.port );
+    this._sock.bind( this._opts.port )
   }
 
   this._sock.on('error', function(err) {
@@ -187,10 +187,10 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
     return
   }
 
-  var block1Buff = getOption(packet.options, 'Block1');
-  var block1;
+  var block1Buff = getOption(packet.options, 'Block1')
+  var block1
   if(block1Buff) {
-    block1 = parseBlockOption(block1Buff);
+    block1 = parseBlockOption(block1Buff)
     // check for error
     if (!block1) {
       req.sender.reset()
@@ -204,7 +204,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
     // var initialRequest = this._msgIdToReq[packet.messageId];
     //If the client takes too long to respond then the retry sender will send
     // another packet with the previous messageId, which we've already removed.
-    var segmentedSender = req.segmentedSender;
+    var segmentedSender = req.segmentedSender
     if(segmentedSender) {
 
       //If there's more to send/receive, then carry on!
@@ -215,13 +215,13 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
           this._msgIdToReq[req._packet.messageId] = req
           segmentedSender.receiveACK(packet, block1)
         } else {
-          segmentedSender.resendPreviousPacket();
+          segmentedSender.resendPreviousPacket()
         }
-        return;
+        return
       } else {
         // console.log("Packet received done");
-        removeOption(req._packet.options, "Block1");
-        delete req.segmentedSender;
+        removeOption(req._packet.options, "Block1")
+        delete req.segmentedSender
       }
     }
   }
@@ -275,7 +275,7 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
         return req.emit('error', new Error('failed to create block2'))
       }
       req.setOption('Block2', block2Val)
-      req._packet.payload = null;
+      req._packet.payload = null
       req.sender.send(generate(req._packet))
 
       return
@@ -313,14 +313,14 @@ Agent.prototype._handle = function handle(msg, rsinfo, outSocket) {
       that._cleanUp()
     })
     response.on('deregister', function() {
-      var deregister_url = Object.assign({}, req.url);
-      deregister_url.observe = 1;
-      deregister_url.token = req._packet.token;
+      var deregister_url = Object.assign({}, req.url)
+      deregister_url.observe = 1
+      deregister_url.token = req._packet.token
 
-      let deregister_req = that.request(deregister_url);
+      let deregister_req = that.request(deregister_url)
       // If the request fails, we'll deal with it with a RST message anyway.
-      deregister_req.on('error', function() {});
-      deregister_req.end();
+      deregister_req.on('error', function() {})
+      deregister_req.end()
     })
   } else {
       response = new IncomingMessage(packet, rsinfo, outSocket)
@@ -342,7 +342,7 @@ Agent.prototype._nextToken = function nextToken() {
   buf.writeUInt32BE(this._lastToken, 0)
   crypto.randomBytes(4).copy(buf, 4)
 
-  return buf;
+  return buf
 }
 
 Agent.prototype._nextMessageId = function nextToken() {
@@ -384,9 +384,9 @@ Agent.prototype.request = function request(url) {
       packet.messageId = that._nextMessageId()
       if ((url.token instanceof Buffer) && (url.token.length > 0)) {
         if (url.token.length > 8) {
-          return req.emit('error', new Error('Token may be no longer than 8 bytes.'));
+          return req.emit('error', new Error('Token may be no longer than 8 bytes.'))
         }
-        packet.token = url.token;
+        packet.token = url.token
       } else {
         packet.token = that._nextToken()
       }
@@ -451,7 +451,7 @@ Agent.prototype.request = function request(url) {
   })
 
   req.sender.on('sent', function() {
-    if (req.multicast) return;
+    if (req.multicast) return
 
     that._msgInFlight--
     if (that._closing && that._msgInFlight === 0) {
@@ -521,7 +521,7 @@ Agent.prototype._convertMulticastToUnicastRequest = function (req, rsinfo) {
   unicastReq.url.host = unicastAddress
   unicastReq.sender._host = unicastAddress
   clearTimeout(unicastReq.multicastTimer)
-  unicastReq.url.multicast = false;
+  unicastReq.url.multicast = false
   req.eventNames().forEach(eventName => {
     req.listeners(eventName).forEach(listener => {
       unicastReq.on(eventName, listener)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -24,8 +24,8 @@ function BlockCache (retentionPeriod, factory) {
   /** @type {{[k:string]:{payload:T,timeoutId:NodeJS.Timeout}}} */
   this._cache = {}
   this._retentionPeriod = retentionPeriod
-  debug("Created cache with " + (this._retentionPeriod/1000) + "s retention period");
-  this._factory = factory;
+  debug("Created cache with " + (this._retentionPeriod/1000) + "s retention period")
+  this._factory = factory
 }
 
 BlockCache.prototype.reset = function () {
@@ -81,4 +81,4 @@ BlockCache.prototype.getWithDefaultInsert = function (key) {
   }
 }
 
-module.exports = BlockCache;
+module.exports = BlockCache

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -17,7 +17,7 @@ var toBinary   = require('./option_converter').toBinary
       , '0.04': 'DELETE'
     }
   , capitalize = require('capitalize')
-  , isIgnored  = require('./option_converter').isIgnored;
+  , isIgnored  = require('./option_converter').isIgnored
 
 module.exports.genAck = function(request) {
   return {
@@ -131,7 +131,7 @@ module.exports.packetToMessage = function packetToMessage(dest, packet) {
 module.exports.hasOption = function hasOption(options, name) {
   for (var i in options)
     if (options[i].name == name)
-      return true;
+      return true
   return null
 }
 
@@ -158,10 +158,10 @@ module.exports.removeOption = function removeOption(options, name) {
   for (var i in options) {
     if (options[i].name == name) {
       delete options[i]
-      return true;
+      return true
     }
   }
-  return false;
+  return false
 }
 
 module.exports.simplifyPacketForPrint = function simplifyPacketForPrint(packetIn) {
@@ -252,7 +252,7 @@ module.exports.createBlock2 = function createBlock2(requestedBlock) {
  * Provide a or function to use with the reduce() Array method
  */
 module.exports.or = function or(previous, current) {
-    return previous || current;
+    return previous || current
 }
 
 /**
@@ -260,14 +260,14 @@ module.exports.or = function or(previous, current) {
  */
 module.exports.isOption = function isOption(optionName) {
   return function(option) {
-    return option.name === optionName;
+    return option.name === optionName
   }
 }
 
 module.exports.isNumeric = function isNumeric(n) {
-  return !isNaN(parseFloat(n)) && isFinite(n);
+  return !isNaN(parseFloat(n)) && isFinite(n)
 }
 
 module.exports.isBoolean = function isBoolean(n) {
-  return typeof(n) === 'boolean';
+  return typeof(n) === 'boolean'
 }

--- a/lib/incoming_message.js
+++ b/lib/incoming_message.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -24,7 +24,7 @@ function parseRequest(request, next) {
 
 function handleServerRequest(request, next) {
   if (request.proxy) {
-    return next();
+    return next()
   }
   try {
     request.server._handle(request.packet, request.rsinfo)
@@ -43,7 +43,7 @@ function proxyRequest(request, next) {
 
   if (request.proxy) {
     if (request.packet.token.length === 0) {
-      request.packet.token = crypto.randomBytes(8);
+      request.packet.token = crypto.randomBytes(8)
     }
 
     request.server._proxiedRequests[request.packet.token.toString('hex')] = request
@@ -54,7 +54,7 @@ function proxyRequest(request, next) {
 }
 
 function isObserve(packet) {
-  return packet.options.map(isOption('Observe')).reduce(or, false);
+  return packet.options.map(isOption('Observe')).reduce(or, false)
 }
 
 function handleProxyResponse(request, next) {

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -51,7 +51,7 @@ ObserveReadStream.prototype.close = function(eagerDeregister) {
   this.push(null)
   this.emit('close')
   if (eagerDeregister) {
-    this.emit('deregister');
+    this.emit('deregister')
   }
 }
 

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -68,9 +68,9 @@ ObserveWriteStream.prototype.reset = function reset() {
   var packet = this._packet
   packet.code = '0.00'
   packet.payload = ''
-  packet.reset = true;
+  packet.reset = true
   packet.ack = false
-  packet.token = Buffer.alloc(0);
+  packet.token = Buffer.alloc(0)
 
   this._send(this, packet)
 

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -13,7 +13,7 @@ var optionToBinaryFunctions = {}
 var optionFromBinaryFunctions = {}
 
 // list of options silently ignored
-var ignoredOptions = {};
+var ignoredOptions = {}
 
 module.exports.toBinary = function(name, value) {
   if (Buffer.isBuffer(value))
@@ -42,7 +42,7 @@ var registerOption = function(name, toBinary, fromBinary) {
 module.exports.registerOption = registerOption
 
 var ignoreOption = function(name) {
-  ignoredOptions[name] = true;
+  ignoredOptions[name] = true
 }
 
 module.exports.ignoreOption = ignoreOption
@@ -83,7 +83,7 @@ var fromUint = function(result) {
 }
 
 var toUint = function(value) {
-  var result = 0;
+  var result = 0
   for (var i = 0; i < value.length; ++i) {
     result = 256 * result + value[i]
   }
@@ -97,11 +97,11 @@ var formatsString = {}
 var formatsBinaries = {}
 
 var registerFormat = function(name, value) {
-  var bytes;
+  var bytes
 
   if (value > 255) {
-    bytes = Buffer.alloc(2);
-    bytes.writeUInt16BE(value, 0);
+    bytes = Buffer.alloc(2)
+    bytes.writeUInt16BE(value, 0)
   } else {
     bytes = Buffer.of(value)
   }

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -85,7 +85,7 @@ OutgoingMessage.prototype.reset = function() {
 
   packet.code = '0.00'
   packet.payload = ''
-  packet.reset = true;
+  packet.reset = true
   packet.ack = false
   packet.token = ''
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
 * Copyright (c) 2013-2015 node-coap contributors.

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 exports.compareBuffers = function (buf1, buf2) {
   if (Buffer.compare)

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -26,7 +26,7 @@ function RetrySend(sock, port, host, maxRetransmit) {
 
   this._host  = host
 
-  this._maxRetransmit = maxRetransmit || parameters.maxRetransmit;
+  this._maxRetransmit = maxRetransmit || parameters.maxRetransmit
   this._sendAttemp = 0
   this._lastMessageId = -1
   this._currentTime = parameters.ackTimeout * (1 + (parameters.ackRandomFactor - 1) * Math.random()) * 1000
@@ -72,7 +72,7 @@ RetrySend.prototype.send = function(message, avoidBackoff) {
   timeout = avoidBackoff ? parameters.maxRTT : parameters.exchangeLifetime
   this._timer = setTimeout(function() {
     var err  = new Error('No reply in ' + timeout + 's')
-    err.retransmitTimeout = timeout;
+    err.retransmitTimeout = timeout
     if (!avoidBackoff)
       that.emit('error', err)
     that.emit('timeout', err)

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -1,6 +1,6 @@
 var generate           = require('coap-packet').generate
  , generateBlockOption = require('./block').generateBlockOption
- , exponentToByteSize  = require('./block').exponentToByteSize;
+ , exponentToByteSize  = require('./block').exponentToByteSize
 
 function SegmentedTransmission(blockSize, req, packet) {
   if(blockSize < 0 || blockSize > 6) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 /*
  * Copyright (c) 2013-2015 node-coap contributors.
@@ -97,15 +97,15 @@ function CoAPServer(options, listener) {
   this._series = series()
   
   this._block1Cache = new BlockCache(parameters.exchangeLifetime * 1000, () => {
-    return {};
+    return {}
   })
   this._block2Cache = new BlockCache(parameters.exchangeLifetime * 1000, () => {
-    return null;
-  });
+    return null
+  })
 
   if (listener)
     this.on('request', listener)
-  debug('initialized');
+  debug('initialized')
 }
 
 util.inherits(CoAPServer, events.EventEmitter)
@@ -132,7 +132,7 @@ function removeProxyOptions(packet) {
 
   packet.options = cleanOptions
 
-  return packet;
+  return packet
 }
 
 CoAPServer.prototype._sendProxied = function(packet, proxyUri, callback) {
@@ -174,8 +174,8 @@ function allAddresses(type) {
     if (type === 'udp6') {
         family = 'IPv6'
     }
-    var addresses = [];
-    var interfaces = os.networkInterfaces();
+    var addresses = []
+    var interfaces = os.networkInterfaces()
     for (var ifname in interfaces)  {
         if (interfaces.hasOwnProperty(ifname)) {
             interfaces[ifname].forEach(function (a) {
@@ -185,7 +185,7 @@ function allAddresses(type) {
             })
         }
     }
-    return addresses;
+    return addresses
 }
 
 CoAPServer.prototype.listen = function(port, address, done) {
@@ -244,7 +244,7 @@ CoAPServer.prototype.listen = function(port, address, done) {
         if (done)
           return done(err)
         else
-          throw err;
+          throw err
       }
 
       if (done)
@@ -291,8 +291,8 @@ CoAPServer.prototype.close = function(done) {
     this._lru.reset()
   }
 
-  this._block2Cache.reset();
-  this._block1Cache.reset();
+  this._block2Cache.reset()
+  this._block1Cache.reset()
 
   return this
 }
@@ -343,9 +343,9 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       return this._sendError(Buffer.from('Observe can only be present with a GET'), rsinfo)
   }
 
-  var cache_key = toCacheKey(rsinfo.address, rsinfo.port, packet);
+  var cache_key = toCacheKey(rsinfo.address, rsinfo.port, packet)
 
-  packet.piggybackReplyMs = this._options.piggybackReplyMs;
+  packet.piggybackReplyMs = this._options.piggybackReplyMs
   var generateResponse = function() {
     var response = new Message(packet, function(response, packet) {
       var buf
@@ -409,8 +409,8 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       debug('check if packet token is in cache, key:', cache_key)
       if (this._block2Cache.contains(cache_key)) {
         debug('found cached payload, key:', cache_key)
-        response.end(this._block2Cache.get(cache_key));
-        return;
+        response.end(this._block2Cache.get(cache_key))
+        return
       }
     }
   }
@@ -434,18 +434,18 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
             .map((str) => {
               return parseInt(str)
             }).sort((a, b) => {
-              return a - b;
-            });
+              return a - b
+            })
           var byteTotalSum = incomingByteIndex + request.payload.length
           var next = 0
           var concat = Buffer.alloc(byteTotalSum)
           for(var i = 0; i < byteOffsets.length; i++) {
             if(byteOffsets[i] == next) {
-              var buff = cachedData[byteOffsets[i]];
-              buff.copy(concat, next, 0, buff.length);
-              next += buff.length;
+              var buff = cachedData[byteOffsets[i]]
+              buff.copy(concat, next, 0, buff.length)
+              next += buff.length
             } else {
-              throw new Error("Byte offset not the next in line...");
+              throw new Error("Byte offset not the next in line...")
             }
           }
           
@@ -454,17 +454,17 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
           if(next == concat.length) {
             request.payload = concat
           } else {
-            throw new Error("Last byte index is not equal to the concat buffer length!");
+            throw new Error("Last byte index is not equal to the concat buffer length!")
           }
         } else {
           // More blocks to come. ACK this block
           response.code = "2.31"
           response.setOption("Block1", block1Buff)
-          response.end();
-          return;
+          response.end()
+          return
         }
       } else {
-        throw new Error("Invalid block state" + blockState);
+        throw new Error("Invalid block state" + blockState)
       }
     }
   }
@@ -495,7 +495,7 @@ inherit from OutgoingMessage
 to handle cached answer and blockwise (2)
 */
 function OutMessage() {
-  OutgoingMessage.apply(this, Array.prototype.slice.call(arguments));
+  OutgoingMessage.apply(this, Array.prototype.slice.call(arguments))
 }
 util.inherits(OutMessage, OutgoingMessage)
 
@@ -571,7 +571,7 @@ OutMessage.prototype.end = function(payload) {
     this._addCacheEntry(this._cachekey, payload)
   }
   OutgoingMessage.prototype.end.call(this, payload.slice((requestedBlockOption.num)*requestedBlockOption.size, (requestedBlockOption.num+1)*requestedBlockOption.size))
-};
+}
 
 /*
 calculate id of a payload by xor each 2-byte-block from it

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.2.0",
+    "eslint": "^7.13.0",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
     "pre-commit": "1.2.2",
@@ -43,5 +44,18 @@
     "fastseries": "^2.0.0",
     "lru-cache": "^5.1.1",
     "readable-stream": "^3.6.0"
+  },
+  "eslintConfig": {
+    "env": {
+      "commonjs": true,
+      "es6": true,
+      "node": true
+    },
+    "rules": {
+      "semi": [
+        "error",
+        "never"
+      ]
+    }
   }
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -15,17 +15,17 @@ var coap     = require('../')
 describe('Agent config', function() {
   it('should get agent instance through custom config', function(done) {
     var agent = coap.Agent({ type: 'udp4', port: 62754 })
-    expect(agent._sock.type).to.eql('udp4');
-    expect(agent._sock._bindState).to.eql(1);
+    expect(agent._sock.type).to.eql('udp4')
+    expect(agent._sock._bindState).to.eql(1)
     done()
   })
 
   it('should get agent instance through custom socket', function(done) {
     var socket = dgram.createSocket('udp6')
     var agent = coap.Agent({ socket, type: 'udp4', port: 62754 })
-    expect(agent._opts.type).to.eql('udp6');
-    expect(agent._sock.type).to.eql('udp6');
-    expect(agent._sock._bindState).to.eql(0);
+    expect(agent._opts.type).to.eql('udp6')
+    expect(agent._sock.type).to.eql('udp6')
+    expect(agent._sock._bindState).to.eql(0)
     done()
   })
 })
@@ -65,7 +65,7 @@ describe('Agent', function() {
 
     server.on('message', function(msg, rsinfo) {
       if (firstRsinfo) {
-        expect(rsinfo.port).to.eql(firstRsinfo.port);
+        expect(rsinfo.port).to.eql(firstRsinfo.port)
         done()
       } else {
         firstRsinfo = rsinfo
@@ -102,7 +102,7 @@ describe('Agent', function() {
     server.on('message', function(msg, rsinfo) {
       var packet = parse(msg)
       if (firstToken) {
-        expect(packet.token).not.to.eql(firstToken);
+        expect(packet.token).not.to.eql(firstToken)
         done()
       } else {
         firstToken = packet.token
@@ -119,7 +119,7 @@ describe('Agent', function() {
     server.on('message', function(msg, rsinfo) {
       var packet = parse(msg)
       if (firstMessageId) {
-        expect(packet.messageId).not.to.eql(firstMessageId);
+        expect(packet.messageId).not.to.eql(firstMessageId)
         done()
       } else {
         firstMessageId = packet.messageId
@@ -289,7 +289,7 @@ describe('Agent', function() {
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
 
       if (firstRsinfo) {
-        expect(rsinfo.port).not.to.eql(firstRsinfo.port);
+        expect(rsinfo.port).not.to.eql(firstRsinfo.port)
         done()
       } else {
         firstRsinfo = rsinfo
@@ -431,7 +431,7 @@ describe('Agent', function() {
 
       server.on('message', function(msg, rsinfo) {
         if (firstRsinfo) {
-          expect(rsinfo.port).not.to.eql(firstRsinfo.port);
+          expect(rsinfo.port).not.to.eql(firstRsinfo.port)
           done()
         } else {
           firstRsinfo = rsinfo

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -238,7 +238,7 @@ describe('blockwise2', function() {
     fillPayloadBuffer(payload_req2)
     fillPayloadBuffer(req1_token)
 
-    var nreq = 1;
+    var nreq = 1
     server.on('request', function(req, res) {
       // only two request to upper level, blockwise transfer completed from cache
       if (nreq == 1)
@@ -360,37 +360,37 @@ describe('blockwise1', () =>{
  describe('Generate Block Options', () => {
    it('it should return buffer', (done) => {
     var payload  = Buffer.of(0x01) 
-    let value = block.generateBlockOption(0, 0, 1);
+    let value = block.generateBlockOption(0, 0, 1)
     expect(payload).to.eql(value)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should return buffer equal to 1,0,1', (done) => {
     var payload  = Buffer.of(0x01, 0x00, 0x01) 
-    let value = block.generateBlockOption(4096, 0, 1);
+    let value = block.generateBlockOption(4096, 0, 1)
     expect(payload).to.eql(value)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should return buffer equal to 1,1', (done) => {
     var payload  = Buffer.of(0x01, 0x01) 
-    let value = block.generateBlockOption(16, 0, 1);
+    let value = block.generateBlockOption(16, 0, 1)
     expect(payload).to.eql(value)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should throw Invalid Parameters error', (done) => {
     expect(() => {
       block.generateBlockOption(0, null, undefined)
     }).to.throw("Invalid parameters")
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should throw Sequence error', (done) => {
     expect(() => {
       block.generateBlockOption(1048576, 0, 0)
     }).to.throw("Sequence number out of range")
-    setImmediate(done);
+    setImmediate(done)
    })
  })
 
@@ -402,9 +402,9 @@ describe('blockwise1', () =>{
       moreBlocks: 0,
       blockSize: 1
     }
-    let value = block.parseBlockOption(payload);
+    let value = block.parseBlockOption(payload)
     expect(value).to.eql(response)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should return object when length is equal to 2', (done) => {
@@ -414,9 +414,9 @@ describe('blockwise1', () =>{
       moreBlocks: 0,
       blockSize: 2
     }
-    let value = block.parseBlockOption(payload);
+    let value = block.parseBlockOption(payload)
     expect(value).to.eql(response)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should return object when length is equal to 3', (done) => {
@@ -426,9 +426,9 @@ describe('blockwise1', () =>{
       moreBlocks: 0,
       blockSize: 3
     }
-    let value = block.parseBlockOption(payload);
+    let value = block.parseBlockOption(payload)
     expect(value).to.eql(response)
-    setImmediate(done);
+    setImmediate(done)
    })
 
    it('it should throw Invalid Block Option error', (done) => {
@@ -436,27 +436,27 @@ describe('blockwise1', () =>{
     expect(() => {
       block.parseBlockOption(payload)
     }).to.throw("Invalid block option buffer length. Must be 1, 2 or 3. It is 4")
-    setImmediate(done);
+    setImmediate(done)
    })
  })
 
  describe('Exponenent to Byte Size', () => {
   it('it should return value', (done) => {
-    let response = 1024;
-    let payload = 6;
-    let value = block.exponentToByteSize(payload);
+    let response = 1024
+    let payload = 6
+    let value = block.exponentToByteSize(payload)
     expect(value).to.eql(response)
-    setImmediate(done);
+    setImmediate(done)
    })
  })
 
  describe('Byte Size to Exponenet', () => {
   it('it should return value', (done) => {
-    let response = 1024;
-    let payload = 6;
-    let value = block.byteSizeToExponent(response);
+    let response = 1024
+    let payload = 6
+    let value = block.byteSizeToExponent(response)
     expect(value).to.eql(payload)
-    setImmediate(done);
+    setImmediate(done)
    })
  })
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -6,87 +6,87 @@
  * See the included LICENSE file for more details.
  */
 
-const { expect } = require('chai');
-const BlockCache = require('../lib/cache');
+const { expect } = require('chai')
+const BlockCache = require('../lib/cache')
 
 describe('Cache', () => {
     describe('Block Cache', () => {
         it('Should set up empty cache object', (done) => {
-            let b = new BlockCache();
-            expect(b._cache).to.eql({});
-            setImmediate(done);
+            let b = new BlockCache()
+            expect(b._cache).to.eql({})
+            setImmediate(done)
         })
     })
 
     describe('Reset', () => {
         it('Should reset all caches', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            b.reset();
-            expect(b._cache).to.eql({});
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            b.reset()
+            expect(b._cache).to.eql({})
+            setImmediate(done)
         })
     })
 
     describe('Add', () => {
         it('Should add to cache', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            expect(b._cache).to.have.own.property('test');
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            expect(b._cache).to.have.own.property('test')
+            setImmediate(done)
         })
         // reuse old cache entry
     })
 
     describe('Remove', () => {
         it('Should from cache', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            b.add('test2', {payload: 'test2'});
-            b.remove('test');
-            expect(b._cache).to.not.have.own.property('test');
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            b.add('test2', {payload: 'test2'})
+            b.remove('test')
+            expect(b._cache).to.not.have.own.property('test')
+            setImmediate(done)
         })
     })
 
     describe('Contains', () => {
         it('Should check if value exists & return true', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            expect(b.contains('test')).to.eql(true);
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            expect(b.contains('test')).to.eql(true)
+            setImmediate(done)
         })
 
         it('Should check if value exists & return false', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            expect(b.contains('test2')).to.eql(false);
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            expect(b.contains('test2')).to.eql(false)
+            setImmediate(done)
         })
     })
 
     describe('Get', () => {
         it('Should return payload from cache', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            expect(b.get('test')).to.eql({payload: 'test'});
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            expect(b.get('test')).to.eql({payload: 'test'})
+            setImmediate(done)
         })
     })
 
     describe('Get Witgh Default Insert', () => {
         it('Should return payload from cache if it exists', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.add('test', {payload: 'test'});
-            expect(b.getWithDefaultInsert('test')).to.eql({payload: 'test'});
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.add('test', {payload: 'test'})
+            expect(b.getWithDefaultInsert('test')).to.eql({payload: 'test'})
+            setImmediate(done)
         })
 
         it('Should add to cache if it doesnt exist', (done) => {
-            let b = new BlockCache(10000, () => { return null});
-            b.getWithDefaultInsert('test');
-            expect(b._cache).to.have.own.property('test');
-            setImmediate(done);
+            let b = new BlockCache(10000, () => { return null})
+            b.getWithDefaultInsert('test')
+            expect(b._cache).to.have.own.property('test')
+            setImmediate(done)
         })
     })
 })

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -24,8 +24,8 @@ describe('end-to-end', function() {
   })*/
 
   process.on('uncaughtException', function (err) {
-    console.log('Caught exception: ' + err);
-  });
+    console.log('Caught exception: ' + err)
+  })
 
   it('should receive a request at a path with some query', function(done) {
     coap.request('coap://localhost:'+port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
@@ -172,7 +172,7 @@ describe('end-to-end', function() {
           var req = {
             port: port,
             options: {}
-          };
+          }
 
           req.options[option] = format
 
@@ -189,7 +189,7 @@ describe('end-to-end', function() {
           var req = {
             port: port,
             headers: {}
-          };
+          }
 
           req.headers[option] = format
 
@@ -260,7 +260,7 @@ describe('end-to-end', function() {
 
   it('should provide a writeHead() method', function(done) {
     var req = coap.request('coap://localhost:' + port)
-    req.end();
+    req.end()
     req.on('response', function(res) {
       expect(res.headers['Content-Format']).to.equal('application/json')
       done()
@@ -410,10 +410,10 @@ describe('end-to-end', function() {
         }).end()
 
     server.on('request', function(req, res) {
-      res.end('hello');
-      expect(req.rsinfo.port).eql(3636);
-      done();
-    });
+      res.end('hello')
+      expect(req.rsinfo.port).eql(3636)
+      done()
+    })
   })
 
   it('should ignore ignored options', function() {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,12 +6,12 @@
  * See the included LICENSE file for more details.
  */
 
-const getOption              = require('../lib/helpers').getOption;
-const hasOption              = require('../lib/helpers').hasOption;
-const removeOption           = require('../lib/helpers').removeOption; 
-const simplifyPacketForPrint = require('../lib/helpers').simplifyPacketForPrint;
-const parseBlock2            = require('../lib/helpers').parseBlock2;
-const createBlock2           = require('../lib/helpers').createBlock2;
+const getOption              = require('../lib/helpers').getOption
+const hasOption              = require('../lib/helpers').hasOption
+const removeOption           = require('../lib/helpers').removeOption 
+const simplifyPacketForPrint = require('../lib/helpers').simplifyPacketForPrint
+const parseBlock2            = require('../lib/helpers').parseBlock2
+const createBlock2           = require('../lib/helpers').createBlock2
 
 describe('Helpers', () => {
 
@@ -84,7 +84,7 @@ describe('Helpers', () => {
                 payload: "Buff: 8",
                 token: "0x01"
             }
-            expect(simplifyPacketForPrint(packet)).to.eql(response);
+            expect(simplifyPacketForPrint(packet)).to.eql(response)
             setImmediate(done)
         })
 
@@ -99,41 +99,41 @@ describe('Helpers', () => {
                 payload: "Buff: 8",
                 token: "0x01"
             }
-            expect(simplifyPacketForPrint(packet)).to.eql(response);
+            expect(simplifyPacketForPrint(packet)).to.eql(response)
             setImmediate(done)
         })
     })
 
     describe('Parse Block2', () => {
         it('Should have case 3 equal 4128', (done) => {
-            let buff = Buffer.from([0x01, 0x02, 0x03]);
+            let buff = Buffer.from([0x01, 0x02, 0x03])
             let res = parseBlock2(buff)
-            expect(res.num).to.eql(4128);
-            setImmediate(done);
+            expect(res.num).to.eql(4128)
+            setImmediate(done)
         })
 
         it('Should return null', (done) => {
-            let buff = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+            let buff = Buffer.from([0x01, 0x02, 0x03, 0x04])
             let res = parseBlock2(buff)
-            expect(res).to.eql(null);
-            setImmediate(done);
+            expect(res).to.eql(null)
+            setImmediate(done)
         })
     })
 
     describe('Create Block2', () => {
         it('Should return a buffer carrying a block 2 value', (done) => {
             let buff = Buffer.from([0xff, 0xff, 0xe9])
-            let block = { moreBlock2: true, num: 1048574, size: 32};
+            let block = { moreBlock2: true, num: 1048574, size: 32}
             let res = createBlock2(block)
-            expect(res).to.eql(buff);
-            setImmediate(done);
+            expect(res).to.eql(buff)
+            setImmediate(done)
         })
 
         it('Should return null', (done) => {
-            let block = { moreBlock2: true, num: 1048576, size: 32};
+            let block = { moreBlock2: true, num: 1048576, size: 32}
             let res = createBlock2(block)
-            expect(res).to.eql(null);
-            setImmediate(done);
+            expect(res).to.eql(null)
+            setImmediate(done)
         })
     })
 

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -17,7 +17,7 @@ describe('Parameters', function() {
 
   it('should ignore empty parameter', function() {
     //WHEN
-    coap.updateTiming();
+    coap.updateTiming()
 
     // THEN
     expect(parameters.maxRTT).to.eql(202)
@@ -34,10 +34,10 @@ describe('Parameters', function() {
       maxRetransmit: 3,
       maxLatency: 5,
       piggybackReplyMs: 6
-    };
+    }
 
     //WHEN
-    coap.updateTiming(coapTiming);
+    coap.updateTiming(coapTiming)
 
     // THEN
     expect(parameters.maxRTT).to.eql(11)

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -63,7 +63,7 @@ describe('proxy', function() {
           done()
         })
       })
-    });
+    })
   })
 
   function send(message) {
@@ -96,18 +96,18 @@ describe('proxy', function() {
 
   it('should resend notifications in an observe connection', function(done) {
     var counter = 0,
-        req;
+        req
 
     clock.restore()
 
     function sendObservation(message) {
       target.on('request', function(req, res) {
-        res.setOption('Observe', 1);
-        res.write('Pruebas');
+        res.setOption('Observe', 1)
+        res.write('Pruebas')
 
         setTimeout(function() {
-          res.write('Pruebas2');
-          res.end('Last msg');
+          res.write('Pruebas2')
+          res.end('Last msg')
         }, 500)
       })
 
@@ -125,9 +125,9 @@ describe('proxy', function() {
         if (counter === 2)
           done()
         else
-          counter++;
+          counter++
 
-        clock.tick(600);
+        clock.tick(600)
       })
     })
   })
@@ -195,7 +195,7 @@ describe('proxy', function() {
       })
 
       request.on('response', function(res) {
-        expect(res.payload.toString()).to.eql('This is the response');
+        expect(res.payload.toString()).to.eql('This is the response')
         done()
       })
 
@@ -205,7 +205,7 @@ describe('proxy', function() {
 
   describe('with a proxied request with a wrong destination', function() {
     it('should return an error to the caller', function(done) {
-      this.timeout(20000);
+      this.timeout(20000)
       var request = coap.request({
         host: 'localhost',
         port: port,
@@ -223,10 +223,10 @@ describe('proxy', function() {
       request
           .on('response', function(res) {
             try {
-              expect(res.code).to.eql('5.00');
-              expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/);
+              expect(res.code).to.eql('5.00')
+              expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/)
             } catch (err) {
-              return done(err);
+              return done(err)
             }
             done()
           })
@@ -252,7 +252,7 @@ describe('proxy', function() {
 
       request
           .on('response', function(res) {
-            expect(res.payload.toString()).to.contain('Standard response');
+            expect(res.payload.toString()).to.contain('Standard response')
             done()
           })
           .end()
@@ -278,7 +278,7 @@ describe('proxy', function() {
 
       request
         .on('response', function(res) {
-          expect(res.payload.toString()).to.contain('Standard response');
+          expect(res.payload.toString()).to.contain('Standard response')
           done()
         })
         .end()
@@ -290,32 +290,32 @@ describe('proxy', function() {
           observe: true,
           query: 'a=b'
         }),
-        count = 0;
+        count = 0
 
       target.on('request', function(req, res) {
         console.log('should not get here')
       })
 
       server.on('request', function(req, res) {
-        res.setOption('Observe', 1);
-        res.write('This is the first response');
+        res.setOption('Observe', 1)
+        res.write('This is the first response')
 
         setTimeout(function() {
-          res.setOption('Observe', 1);
-          res.write('And this is the second');
-        }, 200);
+          res.setOption('Observe', 1)
+          res.write('And this is the second')
+        }, 200)
       })
 
       request
         .on('response', function(res) {
           res.on('data', function(chunk) {
-            count++;
+            count++
 
             if (count === 1) {
-              expect(chunk.toString('utf8')).to.contain('This is the first response');
-              clock.tick(300);
+              expect(chunk.toString('utf8')).to.contain('This is the first response')
+              clock.tick(300)
             } else if (count === 2) {
-              expect(chunk.toString('utf8')).to.contain('And this is the second');
+              expect(chunk.toString('utf8')).to.contain('And this is the second')
               done()
             }
           })

--- a/test/request.js
+++ b/test/request.js
@@ -90,7 +90,7 @@ describe('request', function() {
   })
 
   it('should emit the errors in the req', function (done) {
-    this.timeout(20000);
+    this.timeout(20000)
     var req = request('coap://aaa.eee:' + 1234)
 
     req.once('error', function () {
@@ -219,9 +219,9 @@ describe('request', function() {
 
         var packet = parse(msg)
         expect(packet.token).to.eql(Buffer.from([1,2,3,4,5,6,7,8]))
-        done();
+        done()
       } catch (err) {
-        done(err);
+        done(err)
       }
     })
   })
@@ -238,9 +238,9 @@ describe('request', function() {
 
         var packet = parse(msg)
         expect(packet.token.length).to.be.above(0)
-        done();
+        done()
       } catch (err) {
-        done(err);
+        done(err)
       }
     })
   })
@@ -249,18 +249,18 @@ describe('request', function() {
     var rq = request({
       port: port
       , token: Buffer.from([1,2,3,4,5,6,7,8,9,10])
-    });
+    })
 
     rq.on('error', function(err) {
       if (err.message === 'Token may be no longer than 8 bytes.')
         // Success, this is what we were expecting
-        done();
+        done()
       else
         // Not our error
-        done(err);
-    });
+        done(err)
+    })
 
-    rq.end();
+    rq.end()
 
     server.on('message', function (msg, rsinfo) {
       // We should not see this!
@@ -492,7 +492,7 @@ describe('request', function() {
           , ack: true
           , payload: 'this payload invalidates empty message'
         })
-      expect(packet.code).to.be.eq('0.01');
+      expect(packet.code).to.be.eq('0.01')
       messages++
       server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
     })
@@ -1148,14 +1148,14 @@ describe('request', function() {
           server.on('message', function (msg, rsinfo) {
             var packet = parse(msg)
             if (packet.ack && (packet.code === '0.00'))
-              return;
+              return
 
             try {
-              expect(packet.options.length).to.be.least(1);
+              expect(packet.options.length).to.be.least(1)
               expect(packet.options[0].name).to.eql('Observe')
               expect(packet.options[0].value).to.eql(Buffer.from([1]))
             } catch (err) {
-              return done(err);
+              return done(err)
             }
             done()
           })
@@ -1189,7 +1189,7 @@ describe('request', function() {
           expect(packet.options[0].name).to.eql('Observe')
           expect(packet.options[0].value).to.eql(Buffer.from([1]))
         } catch (err) {
-          return done(err);
+          return done(err)
         }
 
         done()
@@ -1431,11 +1431,11 @@ describe('request', function() {
         sock.addMembership(MULTICAST_ADDR)
         done()
       })
-    });
+    })
 
     afterEach(function() {
       sock.close()
-    });
+    })
 
     it('should be non-confirmable', function (done) {
       var req = doReq()
@@ -1444,7 +1444,7 @@ describe('request', function() {
         var packet = parse(msg)
         expect(packet).to.have.property('confirmable', false)
         done()
-      });
+      })
     })
 
     it('should be responsed with the same token', function (done) {
@@ -1464,7 +1464,7 @@ describe('request', function() {
         })
 
         server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
-      });
+      })
 
       req.on('response', function (res) {
         var packet = res._packet

--- a/test/segmentation.js
+++ b/test/segmentation.js
@@ -6,7 +6,7 @@
  * See the included LICENSE file for more details.
  */
 
-const segment = require('../lib/segmentation');
+const segment = require('../lib/segmentation')
 
 describe('Segmentation', () =>{
 
@@ -14,11 +14,11 @@ describe('Segmentation', () =>{
         it('Should throw invalid block size error', (done) =>{
             expect(() => {
                 segment.SegmentedTransmission(-1, 0, 0)
-            }).to.throw("invalid block size -1");
+            }).to.throw("invalid block size -1")
             expect(() => {
                 segment.SegmentedTransmission(7, 0, 0)
             }).to.throw("invalid block size 7")
-            setImmediate(done);
+            setImmediate(done)
         })
         
     })
@@ -28,7 +28,7 @@ describe('Segmentation', () =>{
             let v = new segment.SegmentedTransmission(1, 1, {payload: [1]})
             v.setBlockSizeExp(6)
             expect(v.blockState.blockSize).to.eql(6)
-            expect(v.byteSize).to.eql(1024);
+            expect(v.byteSize).to.eql(1024)
             setImmediate(done)
         })
     })
@@ -39,13 +39,13 @@ describe('Segmentation', () =>{
         it('Should return true', (done) => {
             let v = new segment.SegmentedTransmission(1, 1, {payload: [1]})
             let value = v.isCorrectACK(1, {sequenceNumber: 0})
-            expect(value).to.eql(true);
+            expect(value).to.eql(true)
             setImmediate(done)
         })
         it('Should return false', (done) => {
             let v = new segment.SegmentedTransmission(1, 1, {payload: [1]})
             let value = v.isCorrectACK(1, {sequenceNumber: 1})
-            expect(value).to.eql(false);
+            expect(value).to.eql(false)
             setImmediate(done)
         })
     })
@@ -53,11 +53,11 @@ describe('Segmentation', () =>{
     describe('Resend Previous Packet', () => {
         it('Should increment resend count', (done) => {
             let v = new segment.SegmentedTransmission(1, 1, {payload: [1]})
-            v.resendCount = 2;
-            v.totalLength = 0;
-            v.currentByte = 1;
+            v.resendCount = 2
+            v.totalLength = 0
+            v.currentByte = 1
             v.resendPreviousPacket()
-            expect(v.resendCount).to.eql(3);
+            expect(v.resendCount).to.eql(3)
             setImmediate(done)
         })
         // should send next packet
@@ -85,9 +85,9 @@ describe('Segmentation', () =>{
             }
             let v = new segment.SegmentedTransmission(1, req, {payload: [1]})
             v.receiveACK(1, {blockSize: 1})
-            v.totalLength = 0;
-            v.currentByte = 0;
-            expect(v.resendCount).to.eql(0);
+            v.totalLength = 0
+            v.currentByte = 0
+            expect(v.resendCount).to.eql(0)
             setImmediate(done)
         })
     })
@@ -95,9 +95,9 @@ describe('Segmentation', () =>{
     describe('Remaining', () => {
         it('Should return a value', (done) => {
             let v = new segment.SegmentedTransmission(1, 1, {payload: [1]})
-            v.totalLength = 0;
-            v.currentByte = 0;
-            expect(v.remaining()).to.eql(0);
+            v.totalLength = 0
+            v.currentByte = 0
+            expect(v.remaining()).to.eql(0)
             setImmediate(done)
         })
     })

--- a/test/server.js
+++ b/test/server.js
@@ -256,7 +256,7 @@ describe('server', function() {
       expect(result.token.length).to.eql(0)
       expect(result.payload.length).to.eql(0)
       done()
-    });
+    })
     server.on('request', function(req, res) {
       res.reset()
     })
@@ -334,7 +334,7 @@ describe('server', function() {
       }))
 
       client.on('message', function(msg) {
-        var response = parse(msg);
+        var response = parse(msg)
 
         expect(response.code).to.equal('2.05')
 
@@ -356,7 +356,7 @@ describe('server', function() {
       }))
 
       client.on('message', function(msg) {
-        var response = parse(msg);
+        var response = parse(msg)
 
         expect(response.code).to.equal('2.05')
 
@@ -680,7 +680,7 @@ describe('server', function() {
           // original one plus 4 retries
           expect(messages).to.eql(5)
         } catch (err) {
-          return done(err);
+          return done(err)
         }
         done()
       }, 45 * 1000)
@@ -924,7 +924,7 @@ describe('server', function() {
         expect(result.ack).to.eql(false)
         expect(result.payload.length).to.eql(0)
 
-        done();
+        done()
       })
     })
 
@@ -1032,7 +1032,7 @@ describe('validate custom server options', function() {
 
   it('use custom piggyBackTimeout time', function(done) {
     var piggyBackTimeout = 10
-    var messages = 0;
+    var messages = 0
     server = coap.createServer({ piggybackReplyMs: piggyBackTimeout })
     server.listen(port)
     server.on('request', function(req, res) {
@@ -1105,7 +1105,7 @@ describe('validate custom server options', function() {
   }
 
   it('should send ACK for non-confirmable message, sendAcksForNonConfirmablePackets=true', function(done) {
-    var messages = 0;
+    var messages = 0
     server = coap.createServer({ sendAcksForNonConfirmablePackets: true })
     server.listen(port)
     server.on('request', function(req, res) {
@@ -1119,7 +1119,7 @@ describe('validate custom server options', function() {
   })
 
   it('should not send ACK for non-confirmable message, sendAcksForNonConfirmablePackets=false', function(done) {
-    var messages = 0;
+    var messages = 0
     server = coap.createServer({ sendAcksForNonConfirmablePackets: false })
     server.listen(port)
     server.on('request', function(req, res) {
@@ -1142,7 +1142,7 @@ describe('validate custom server options', function() {
       res.end('42')
     })
     client.on('message', function(msg) {
-      done();
+      done()
     })
     sendConfirmableMessage()
   })


### PR DESCRIPTION
This PR removes obsolete semicolons from the source code and introduces linting with ESLint. It is a softer approach than #251. After the biggest issues with the code have been resolved the StandardJS linter can be added as a last step.