### PR TITLE
feat: add `clientIdentifier` option to `createServer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The constructor can be given an optional options object, containing one of the f
 * `piggybackReplyMs`: set the number of milliseconds to wait for a
   piggyback response. Default 50.
 * `sendAcksForNonConfirmablePackets`: Optional. Use this to suppress sending ACK messages for non-confirmable packages
+* `clientIdentifier`: Optional. If specified, it should be a callback function with a signature like `clientIdentifier(request)`, where request is an `IncomingMessage`. The function should return a string that the caches can assume will uniquely identify the client.
 
 #### Event: 'request'
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -65,6 +65,14 @@ function CoAPServer(options, listener) {
     this._middlewares.push(middlewares.handleProxyResponse)
   }
 
+  if (typeof options.clientIdentifier === 'function') {
+    this._clientIdentifier = options.clientIdentifier
+  } else {
+    this._clientIdentifier = (request) => {
+      return `${request.rsinfo.address}:${request.rsinfo.port}`
+    }    
+  }
+
   if (!this._options.piggybackReplyMs || !isNumeric(this._options.piggybackReplyMs)) {
     this._options.piggybackReplyMs = parameters.piggybackReplyMs
   }
@@ -84,8 +92,14 @@ function CoAPServer(options, listener) {
   // 32 MB / 1280 = 26214
   // The max lifetime is roughly 200s per packet.
   // Which gave us 131 packets/second guarantee
+  let max = 32768 * 1024
+
+  if (typeof options.cacheSize === 'number' && options.cacheSize >= 0) {
+    max = options.cacheSize
+  }
+
   this._lru = new LRU({
-      max: options.cacheSize || (32768 * 1024)
+      max
     , length: function(n) { return n.buffer.byteLength }
     , maxAge: (parameters.exchangeLifetime * 1000)
     , dispose:  function(key, value) {
@@ -316,11 +330,10 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
 
   var sock      = this._sock
     , lru       = this._lru
-    // , acks      = this._acks
-    , cached    = lru.peek(toKey(rsinfo.address, rsinfo.port, packet, true))
     , Message   = OutMessage
     , that = this
-    , request
+    , request   = new IncomingMessage(packet, rsinfo)
+    , cached    = lru.peek(this._toKey(request, packet, true))
     , response
 
   if (cached && !packet.ack && !packet.reset) {
@@ -329,12 +342,11 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
     if (cached.response && packet.reset) {
       cached.response.end()
     }
-    return lru.del(toKey(rsinfo.address, rsinfo.port, packet, false))
+    return lru.del(this._toKey(request, packet, false))
   } else if (packet.ack || packet.reset) {
     return // nothing to do, ignoring silently
   }
 
-  request = new IncomingMessage(packet, rsinfo)
 
   if (request.headers['Observe'] === 0) {
     Message = ObserveStream
@@ -343,7 +355,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
       return this._sendError(Buffer.from('Observe can only be present with a GET'), rsinfo)
   }
 
-  var cache_key = toCacheKey(rsinfo.address, rsinfo.port, packet)
+  var cache_key = this._toCacheKey(request, packet)
 
   packet.piggybackReplyMs = this._options.piggybackReplyMs
   var generateResponse = function() {
@@ -365,7 +377,7 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
         })
       }
   
-      var key = toKey(rsinfo.address, rsinfo.port,
+      var key = that._toKey(request, 
           packet, packet.ack || !packet.confirmable)
       lru.set(key, buf)
       buf.sender = sender
@@ -472,16 +484,16 @@ CoAPServer.prototype._handle = function(packet, rsinfo) {
   this.emit('request', request, response)
 }
 
-function toCacheKey(address, port, packet) {
+CoAPServer.prototype._toCacheKey = function toCacheKey(request, packet) {
   if (packet.token && packet.token.length > 0) {
-    return packet.token.toString('hex') + '/' + address + ':' + port
+    return `${packet.token.toString('hex')}/${this._clientIdentifier(request)}`
   }
 
   return null
 }
 
-function toKey(address, port, packet, appendToken) {
-  var result = address + port + packet.messageId
+CoAPServer.prototype._toKey = function toKey(request, packet, appendToken) {
+  var result = `${this._clientIdentifier(request)}/${packet.messageId}`
 
   if (appendToken)
     result += packet.token.toString('hex')

--- a/test/server.js
+++ b/test/server.js
@@ -1265,7 +1265,7 @@ describe('server block cache', function() {
 
 })
 
-describe('server LRU', function() {
+describe('Client Identifier', function() {
   var server
       , port
       , clientPort

--- a/test/server.js
+++ b/test/server.js
@@ -1264,3 +1264,103 @@ describe('server block cache', function() {
   })
 
 })
+
+describe('server LRU', function() {
+  var server
+      , port
+      , clientPort
+      , client
+      , clock
+
+  const packet = function(key) {
+    return {
+      confirmable: true
+      , messageId: 4242
+      , token: new Buffer(5)
+      , options: [
+        {name: 2109, value: Buffer.from(key) }
+      ]
+    }
+  }
+
+  beforeEach(function (done) {
+    clock = sinon.useFakeTimers()
+    port = nextPort()
+
+    server = coap.createServer({
+      clientIdentifier: (request) => {
+        const authenticationHeader = request.options.find(o => o.name === '2109')
+
+        if (typeof authenticationHeader !== 'undefined') {
+          return `auth:${authenticationHeader.value.toString()}`
+
+        }
+        return `unauth:${request.rsinfo.address}:${request.rsinfo.port}`
+      },
+    })
+    server.listen(port, done)
+  })
+
+  beforeEach(function (done) {
+    clientPort = nextPort()
+    client = dgram.createSocket('udp4')
+    client.bind(clientPort, done)
+  })
+
+  afterEach(function () {
+    clock.restore()
+    client.close()
+    server.close()
+    tk.reset()
+  })
+
+  function send(message) {
+    client.send(message, 0, message.length, port, '127.0.0.1')
+  }
+
+  it('should share the cache between two requests of the same client', function (done) {
+    let messagesSent = 0
+    let messagesReceived = 0
+
+    server.on('request', function (req, res) {
+      res.end(`${messagesSent}`)
+      messagesSent += 1
+    })
+
+    client.on('message', function(msg) {
+      const result = parse(msg)
+      expect(result.payload.toString(), '0')
+      messagesReceived += 1
+
+      if (messagesReceived === 2) {
+        done()
+      }
+    })
+
+    send(generate(packet('key1')))
+    send(generate(packet('key1')))
+  })
+
+  it('should not share the cache between requests of different clients', function (done) {
+    let messagesSent = 0
+    let messagesReceived = 0
+
+    server.on('request', function (req, res) {
+      res.end(`${messagesSent}`)
+      messagesSent += 1
+    })
+
+    client.on('message', function(msg) {
+      const result = parse(msg)
+      expect(result.payload.toString(), `${messagesReceived}`)
+      messagesReceived += 1
+
+      if (messagesReceived === 2) {
+        done()
+      }
+    })
+
+    send(generate(packet('key1')))
+    send(generate(packet('key2')))
+  })
+})


### PR DESCRIPTION
This PR is a follow-up to #190. It fixes a couple of issues that were present on that branch, cleans up the commit history, and removes the added `package.json` file.