### PR TITLE
feat: add support for FETCH, PATCH, and iPATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This library follows:
 * [RFC 7641](https://datatracker.ietf.org/doc/html/rfc7641)
   for the observe specification,
 * [RFC 7959](https://datatracker.ietf.org/doc/html/rfc7959) for
-  the blockwise specification.
+  the blockwise specification,
+* [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132) for the PATCH, FETCH, and iPATCH methods.
 
 It does not parse the protocol but it use
 [CoAP-packet](http://github.com/mcollina/coap-packet) instead.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,10 @@ const codes = {
     0.01: 'GET',
     0.02: 'POST',
     0.03: 'PUT',
-    0.04: 'DELETE'
+    0.04: 'DELETE',
+    0.05: 'FETCH',
+    0.06: 'PATCH',
+    0.07: 'iPATCH'
 }
 const capitalize = require('capitalize')
 const isIgnored = require('./option_converter').isIgnored

--- a/lib/server.js
+++ b/lib/server.js
@@ -373,6 +373,15 @@ class CoAPServer extends events.EventEmitter {
             }
         }
 
+        if (packet.code === '0.05' && request.headers['Content-Format'] == null) {
+            return this._sendError(
+                Buffer.from('FETCH requests must contain a Content-Format option'),
+                rsinfo,
+                null,
+                '4.15' /* TODO: Check if this is the correct error code */
+            )
+        }
+
         const cacheKey = this._toCacheKey(request, packet)
 
         packet.piggybackReplyMs = this._options.piggybackReplyMs

--- a/lib/server.js
+++ b/lib/server.js
@@ -187,9 +187,9 @@ class CoAPServer extends events.EventEmitter {
         debug('initialized')
     }
 
-    _sendError (payload, rsinfo, packet) {
+    _sendError (payload, rsinfo, packet, code = '5.00') {
         const message = generate({
-            code: '5.00',
+            code,
             payload: payload,
             messageId: packet ? packet.messageId : undefined,
             token: packet ? packet.token : undefined

--- a/lib/server.js
+++ b/lib/server.js
@@ -364,10 +364,10 @@ class CoAPServer extends events.EventEmitter {
 
         if (request.headers.Observe === 0) {
             Message = ObserveStream
-            if (packet.code !== '0.01') {
-                // it is not a GET
+            if (packet.code !== '0.01' && packet.code !== '0.05') {
+                // it is neither a GET nor a FETCH
                 return this._sendError(
-                    Buffer.from('Observe can only be present with a GET'),
+                    Buffer.from('Observe can only be present with a GET or a FETCH'),
                     rsinfo
                 )
             }

--- a/test/server.js
+++ b/test/server.js
@@ -169,13 +169,30 @@ describe('server', function () {
         })
     })
 
-    ;['GET', 'POST', 'PUT', 'DELETE'].forEach(function (method) {
+    ;['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'iPATCH'].forEach(function (method) {
         it('should include the \'' + method + '\' method', function (done) {
             send(generate({ code: method }))
             server.on('request', function (req, res) {
                 expect(req).to.have.property('method', method)
                 done()
             })
+        })
+    })
+
+    it('should include the FETCH method when a Content-Format is present', function (done) {
+        send(generate({ code: 'FETCH', options: [{ name: 'Content-Format', value: Buffer.of(0x06, 0x06) }] }))
+        server.on('request', function (req, res) {
+            expect(req).to.have.property('method', 'FETCH')
+            done()
+        })
+    })
+
+    it('should respond with an error to a FETCH request when no Content-Format is present', function (done) {
+        send(generate({ code: 'FETCH' }))
+
+        client.on('message', function (msg, rsinfo) {
+            expect(parse(msg).code).to.eql('4.15')
+            done()
         })
     })
 
@@ -803,7 +820,7 @@ describe('server', function () {
             }))
         }
 
-        ['PUT', 'POST', 'DELETE'].forEach(function (method) {
+        ['PUT', 'POST', 'DELETE', 'PATCH', 'iPATCH'].forEach(function (method) {
             it('should return an error when try to observe in a ' + method, function (done) {
                 doObserve(method)
                 server.on('request', function () {


### PR DESCRIPTION
This PR adds support for the FETCH, PATCH, and iPATCH CoAP methods, as specified in [RFC 8132](https://datatracker.ietf.org/doc/html/rfc8132). I still need to figure out what is actually needed to fully support these methods (besides the status codes), so this PR is for now only opened as a draft.