### PR TITLE
fix(agent): reset _lastMessageId to 0

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -332,7 +332,7 @@ class Agent extends events.EventEmitter {
 
     _nextMessageId () {
         if (++this._lastMessageId === maxMessageId) {
-            this._lastMessageId = 1
+            this._lastMessageId = 0
         }
 
         return this._lastMessageId

--- a/test/agent.js
+++ b/test/agent.js
@@ -88,7 +88,7 @@ describe('Agent', function () {
             if (total === 2) {
                 // nothing to do
             } else if (total === 1) {
-                expect(parse(msg).messageId).to.eql(1)
+                expect(parse(msg).messageId).to.eql(0)
                 done()
             }
 


### PR DESCRIPTION
This is a small fix which allows message IDs to be set to 0 if the maximum message ID value has been reached. This makes the implementation a bit more consistent as the initial message ID can actually be 0.

As a bug in `coap-packet` has been fixed that caused errors when the ID was 0 this change should be fine to add now.