### PR TITLE
refactor: replace deprecated URL.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,16 @@ first ten come from different ports.
 
 -------------------------------------------------------
 <a name="request"></a>
-### request(url)
+### request(requestParams)
 
-Execute a CoAP request. `url` can be a string or an object.
-If it is a string, it is parsed using `require('url').parse(url)`.
+Execute a CoAP request. `requestParams` can be a string or an object.
+If it is a string, it is parsed using `new URL(requestParams)`.
 If it is an object:
 
 - `host`: A domain name or IP address of the server to issue the request
   to.
   Defaults to `'localhost'`.
-- `hostname`: To support `url.parse()` `hostname` is preferred over
+- `hostname`: To support `URL` `hostname` is preferred over
   `host`
 - `port`: Port of remote server. Defaults to 5683.
 - `method`: A string specifying the CoAP request method. Defaults to

--- a/examples/blockwise.js
+++ b/examples/blockwise.js
@@ -1,8 +1,7 @@
 const coap = require('../') // or coap
-const url = require('url')
 
 coap.createServer((req, res) => {
-    const path = url.parse(req.url) // eslint-disable-line node/no-deprecated-api
+    const path = new URL(req.url)
     const time = parseInt(path.search.split('=')[1])
     const pathname = path.pathname.split('/')[1]
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -199,7 +199,7 @@ class CoAPServer extends events.EventEmitter {
     }
 
     _sendProxied (packet, proxyUri, callback) {
-        const url = require('url').parse(proxyUri) // eslint-disable-line node/no-deprecated-api
+        const url = new URL(proxyUri)
         const host = url.hostname
         const port = url.port
         const message = generate(removeProxyOptions(packet))


### PR DESCRIPTION
This PR replaces `URL.parse` which is deprecated according to eslint. It fixes #267.