### PR TITLE
fix: add support for `text/plain; charset=utf-8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ registry](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml
 These are the defaults formats:
 ```js
 registerFormat('text/plain', 0)
+registerFormat('text/plain; charset=utf-8', 0)
 registerFormat('application/link-format', 40)
 registerFormat('application/xml', 41)
 registerFormat('application/octet-stream', 42)

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -118,6 +118,7 @@ module.exports.registerFormat = registerFormat
 // See https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 // for a list of all registered content-formats
 registerFormat('text/plain', 0)
+registerFormat('text/plain; charset=utf-8', 0)
 registerFormat('application/link-format', 40)
 registerFormat('application/xml', 41)
 registerFormat('application/octet-stream', 42)

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -152,7 +152,7 @@ describe('end-to-end', function () {
     })
 
     describe('formats', function () {
-        const formats = ['text/plain', 'application/link-format',
+        const formats = ['text/plain; charset=utf-8', 'application/link-format',
             'application/xml', 'application/octet-stream',
             'application/exi', 'application/json', 'application/cbor']
 
@@ -243,6 +243,19 @@ describe('end-to-end', function () {
         server.once('request', (req) => {
             expect(req.options[0].name).to.equal('Content-Format')
             expect(req.options[0].value).to.equal('application/json')
+            done()
+        })
+    })
+
+    it('should support the \'Content-Format\' text/plain', function (done) {
+        const req = coap.request('coap://localhost:' + port)
+
+        req.setOption('Content-Format', 'text/plain')
+        req.end()
+
+        server.once('request', function (req) {
+            expect(req.options[0].name).to.equal('Content-Format')
+            expect(req.options[0].value).to.equal('text/plain; charset=utf-8')
             done()
         })
     })

--- a/test/request.js
+++ b/test/request.js
@@ -663,7 +663,7 @@ describe('request', function () {
     })
 
     const formatsString = {
-        'text/plain': Buffer.of(0),
+        'text/plain; charset=utf-8': Buffer.of(0),
         'application/link-format': Buffer.of(40),
         'application/xml': Buffer.of(41),
         'application/octet-stream': Buffer.of(42),

--- a/test/server.js
+++ b/test/server.js
@@ -286,7 +286,7 @@ describe('server', function () {
     })
 
     const formatsString = {
-        'text/plain': Buffer.of(0),
+        'text/plain; charset=utf-8': Buffer.of(0),
         'application/link-format': Buffer.of(40),
         'application/xml': Buffer.of(41),
         'application/octet-stream': Buffer.of(42),
@@ -557,7 +557,7 @@ describe('server', function () {
             send(generate())
 
             server.on('request', (req, res) => {
-                res.setOption('Content-Format', 'text/plain')
+                res.setOption('Content-Format', 'text/plain; charset=utf-8')
                 res.end('42')
             })
 

--- a/test/share-socket.js
+++ b/test/share-socket.js
@@ -147,7 +147,7 @@ describe('share-socket', function () {
     })
 
     describe('formats', function () {
-        const formats = ['text/plain', 'application/link-format',
+        const formats = ['text/plain; charset=utf-8', 'application/link-format',
             'application/xml', 'application/octet-stream',
             'application/exi', 'application/json', 'application/cbor']
 


### PR DESCRIPTION
This PR fixes #33. It adds support for the Content-Format `text/plain; charset=utf-8` as an input parameter. The default output Content-Format will now be changed to `text/plain; charset=utf-8` so this might actually be a breaking change. I hope, however, that other implementations will be able to handle this.