### PR TITLE
refactor(agent): remove obsolete DNS bug check

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,17 +25,8 @@ const removeOption = require('./helpers').removeOption
 const maxToken = Math.pow(2, 32)
 const maxMessageId = Math.pow(2, 16)
 const pf = require('./polyfill')
-let hasDNSbug = true
 const SegmentedTransmission = require('./segmentation').SegmentedTransmission
-const parseBlockOption = require('./block').parseBlockOption;
-
-(function () {
-    const major = parseInt(process.version.match(/^v([^.]+).*$/)[1])
-
-    if (major >= 4) {
-        hasDNSbug = false
-    }
-})()
+const parseBlockOption = require('./block').parseBlockOption
 
 function Agent (opts) {
     if (!(this instanceof Agent)) {
@@ -93,10 +84,7 @@ Agent.prototype._init = function initSock (socket) {
     }
 
     this._sock.on('error', function (err) {
-    // we are skipping DNS errors
-        if (!hasDNSbug || err.code !== 'ENOTFOUND') {
-            that.emit('error', err)
-        }
+        that.emit('error', err)
     })
 
     this._msgIdToReq = {}


### PR DESCRIPTION
This PR removes code that checks for node version 4 which is EOL for a couple of years.