### PR TITLE
refactor: replace `that` with `this` by using arrow functions

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -56,9 +56,8 @@ class Agent extends events.EventEmitter {
             return
         }
 
-        const that = this
         this._sock = socket || dgram.createSocket(this._opts.type)
-        this._sock.on('message', function (msg, rsinfo) {
+        this._sock.on('message', (msg, rsinfo) => {
             let packet
             try {
                 packet = parse(msg)
@@ -71,16 +70,16 @@ class Agent extends events.EventEmitter {
                 return
             }
 
-            const outSocket = that._sock.address()
-            that._handle(msg, rsinfo, outSocket)
+            const outSocket = this._sock.address()
+            this._handle(msg, rsinfo, outSocket)
         })
 
         if (this._opts.port) {
             this._sock.bind(this._opts.port)
         }
 
-        this._sock.on('error', function (err) {
-            that.emit('error', err)
+        this._sock.on('error', (err) => {
+            this.emit('error', err)
         })
 
         this._msgIdToReq = {}
@@ -127,16 +126,15 @@ class Agent extends events.EventEmitter {
         const packet = parse(msg)
         let buf
         let response
-        const that = this
         let req = this._msgIdToReq[packet.messageId]
-        const ackSent = function (err) {
+        const ackSent = (err) => {
             if (err && req) {
                 req.emit('error', err)
             }
 
-            that._msgInFlight--
-            if (that._closing && that._msgInFlight === 0) {
-                that._doClose()
+            this._msgInFlight--
+            if (this._closing && this._msgInFlight === 0) {
+                this._doClose()
             }
         }
         if (!req) {
@@ -201,7 +199,7 @@ class Agent extends events.EventEmitter {
                 if (segmentedSender.remaining() > 0) {
                     if (segmentedSender.isCorrectACK(packet, block1)) {
                         delete this._msgIdToReq[req._packet.messageId]
-                        req._packet.messageId = that._nextMessageId()
+                        req._packet.messageId = this._nextMessageId()
                         this._msgIdToReq[req._packet.messageId] = req
                         segmentedSender.receiveACK(packet, block1)
                     } else {
@@ -250,7 +248,7 @@ class Agent extends events.EventEmitter {
             if (block2.moreBlock2) {
                 // increase message id for next request
                 delete this._msgIdToReq[req._packet.messageId]
-                req._packet.messageId = that._nextMessageId()
+                req._packet.messageId = this._nextMessageId()
                 this._msgIdToReq[req._packet.messageId] = req
 
                 // next block2 request
@@ -286,24 +284,24 @@ class Agent extends events.EventEmitter {
                 return
             }
         } else if (block2) {
-            delete that._tkToReq[req._packet.token.toString('hex')]
+            delete this._tkToReq[req._packet.token.toString('hex')]
         } else if (!req.url.observe && !req.multicast) {
         // it is not, so delete the token
-            delete that._tkToReq[packet.token.toString('hex')]
+            delete this._tkToReq[packet.token.toString('hex')]
         }
 
         if (req.url.observe && packet.code !== '4.04') {
             response = new ObserveStream(packet, rsinfo, outSocket)
-            response.on('close', function () {
-                delete that._tkToReq[packet.token.toString('hex')]
-                that._cleanUp()
+            response.on('close', () => {
+                delete this._tkToReq[packet.token.toString('hex')]
+                this._cleanUp()
             })
-            response.on('deregister', function () {
+            response.on('deregister', () => {
                 const deregisterUrl = Object.assign({}, req.url)
                 deregisterUrl.observe = 1
                 deregisterUrl.token = req._packet.token
 
-                const deregisterReq = that.request(deregisterUrl)
+                const deregisterReq = this.request(deregisterUrl)
                 // If the request fails, we'll deal with it with a RST message anyway.
                 deregisterReq.on('error', function () {})
                 deregisterReq.end()
@@ -349,10 +347,9 @@ class Agent extends events.EventEmitter {
 
         const options = url.options || url.headers
         let option
-        const that = this
         const multicastTimeout = url.multicastTimeout !== undefined ? parseInt(url.multicastTimeout) : 20000
 
-        const req = new OutgoingMessage({}, function (req, packet) {
+        const req = new OutgoingMessage({}, (req, packet) => {
             let buf
 
             if (url.confirmable !== false) {
@@ -367,25 +364,25 @@ class Agent extends events.EventEmitter {
 
             let token
             if (!(packet.ack || packet.reset)) {
-                packet.messageId = that._nextMessageId()
+                packet.messageId = this._nextMessageId()
                 if ((url.token instanceof Buffer) && (url.token.length > 0)) {
                     if (url.token.length > 8) {
                         return req.emit('error', new Error('Token may be no longer than 8 bytes.'))
                     }
                     packet.token = url.token
                 } else {
-                    packet.token = that._nextToken()
+                    packet.token = this._nextToken()
                 }
                 token = packet.token.toString('hex')
-                that._tkToMulticastResAddr[token] = []
+                this._tkToMulticastResAddr[token] = []
                 if (req.multicast) {
-                    that._tkToMulticastResAddr[token] = []
+                    this._tkToMulticastResAddr[token] = []
                 }
             }
 
-            that._msgIdToReq[packet.messageId] = req
+            this._msgIdToReq[packet.messageId] = req
             if (token) {
-                that._tkToReq[token] = req
+                this._tkToReq[token] = req
             }
 
             const block1Buff = getOption(packet.options, 'Block1')
@@ -427,36 +424,36 @@ class Agent extends events.EventEmitter {
 
         req.sender.on('error', req.emit.bind(req, 'error'))
 
-        req.sender.on('sending', function () {
-            that._msgInFlight++
+        req.sender.on('sending', () => {
+            this._msgInFlight++
         })
 
-        req.sender.on('timeout', function (err) {
+        req.sender.on('timeout', (err) => {
             req.emit('timeout', err)
-            that.abort(req)
+            this.abort(req)
         })
 
-        req.sender.on('sent', function () {
+        req.sender.on('sent', () => {
             if (req.multicast) return
 
-            that._msgInFlight--
-            if (that._closing && that._msgInFlight === 0) {
-                that._doClose()
+            this._msgInFlight--
+            if (this._closing && this._msgInFlight === 0) {
+                this._doClose()
             }
         })
 
         // Start multicast monitoring timer in case of multicast request
         if (url.multicast === true) {
-            req.multicastTimer = setTimeout(function () {
+            req.multicastTimer = setTimeout(() => {
                 if (req._packet.token) {
                     const token = req._packet.token.toString('hex')
-                    delete that._tkToReq[token]
-                    delete that._tkToMulticastResAddr[token]
+                    delete this._tkToReq[token]
+                    delete this._tkToMulticastResAddr[token]
                 }
-                delete that._msgIdToReq[req._packet.messageId]
-                that._msgInFlight--
-                if (that._msgInFlight === 0 && that._closing) {
-                    that._doClose()
+                delete this._msgIdToReq[req._packet.messageId]
+                this._msgInFlight--
+                if (this._msgInFlight === 0 && this._closing) {
+                    this._doClose()
                 }
             }, multicastTimeout)
         }

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -30,10 +30,9 @@ class ObserveWriteStream extends Writable {
 
         this._counter = 0
 
-        const that = this
-        this.on('finish', function () {
-            if (that._counter === 0) { // we have sent no messages
-                that._doSend(null)
+        this.on('finish', () => {
+            if (this._counter === 0) { // we have sent no messages
+                this._doSend(null)
             }
         })
     }

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -25,24 +25,22 @@ class OutgoingMessage extends BufferList {
             reset: false
         }
 
-        const that = this
-
         if (request.confirmable) {
         // replying in piggyback
             this._packet.ack = true
 
-            this._ackTimer = setTimeout(function () {
-                send(that, helpers.genAck(request))
+            this._ackTimer = setTimeout(() => {
+                send(this, helpers.genAck(request))
 
                 // we are no more in piggyback
-                that._packet.confirmable = true
-                that._packet.ack = false
+                this._packet.confirmable = true
+                this._packet.ack = false
 
                 // we need a new messageId for the CON
                 // reply
-                delete that._packet.messageId
+                delete this._packet.messageId
 
-                that._ackTimer = null
+                this._ackTimer = null
             }, request.piggybackReplyMs)
         }
 

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -15,7 +15,6 @@ const parse = require('coap-packet').parse
 class RetrySend extends EventEmitter {
     constructor (sock, port, host, maxRetransmit) {
         super()
-        const that = this
 
         this._sock = sock
 
@@ -28,20 +27,18 @@ class RetrySend extends EventEmitter {
         this._lastMessageId = -1
         this._currentTime = parameters.ackTimeout * (1 + (parameters.ackRandomFactor - 1) * Math.random()) * 1000
 
-        this._bOff = function () {
-            that._currentTime = that._currentTime * 2
-            that._send()
+        this._bOff = () => {
+            this._currentTime = this._currentTime * 2
+            this._send()
         }
     }
 
     _send (avoidBackoff) {
-        const that = this
-
         this._sock.send(this._message, 0, this._message.length,
-            this._port, this._host, function (err, bytes) {
-                that.emit('sent', err, bytes)
+            this._port, this._host, (err, bytes) => {
+                this.emit('sent', err, bytes)
                 if (err) {
-                    that.emit('error', err)
+                    this.emit('error', err)
                 }
             })
 
@@ -59,19 +56,17 @@ class RetrySend extends EventEmitter {
     }
 
     send (message, avoidBackoff) {
-        const that = this
-
         this._message = message
         this._send(avoidBackoff)
 
         const timeout = avoidBackoff ? parameters.maxRTT : parameters.exchangeLifetime
-        this._timer = setTimeout(function () {
+        this._timer = setTimeout(() => {
             const err = new Error('No reply in ' + timeout + 's')
             err.retransmitTimeout = timeout
             if (!avoidBackoff) {
-                that.emit('error', err)
+                this.emit('error', err)
             }
-            that.emit('timeout', err)
+            this.emit('timeout', err)
         }, timeout * 1000)
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -216,8 +216,6 @@ class CoAPServer extends events.EventEmitter {
     }
 
     listen (port, address, done) {
-        const that = this
-
         if (port == null) {
             port = parameters.coapPort
         }
@@ -253,22 +251,22 @@ class CoAPServer extends events.EventEmitter {
                 reuseAddr: true
             })
 
-            this._sock.bind(port, address || null, function () {
+            this._sock.bind(port, address || null, () => {
                 try {
-                    if (that._multicastAddress) {
-                        that._sock.setMulticastLoopback(true)
+                    if (this._multicastAddress) {
+                        this._sock.setMulticastLoopback(true)
 
-                        if (that._multicastInterface) {
-                            that._sock.addMembership(
-                                that._multicastAddress,
-                                that._multicastInterface
+                        if (this._multicastInterface) {
+                            this._sock.addMembership(
+                                this._multicastAddress,
+                                this._multicastInterface
                             )
                         } else {
-                            allAddresses(that._options.type).forEach(function (
+                            allAddresses(this._options.type).forEach((
                                 _interface
-                            ) {
-                                that._sock.addMembership(
-                                    that._multicastAddress,
+                            ) => {
+                                this._sock.addMembership(
+                                    this._multicastAddress,
                                     _interface
                                 )
                             })
@@ -285,14 +283,14 @@ class CoAPServer extends events.EventEmitter {
 
         this._sock.on('message', handleRequest(this))
 
-        this._sock.on('error', function (error) {
-            that.emit('error', error)
+        this._sock.on('error', (error) => {
+            this.emit('error', error)
         })
 
         if (parameters.pruneTimerPeriod) {
             // Start LRU pruning timer
-            this._lru.pruneTimer = setInterval(function () {
-                that._lru.prune()
+            this._lru.pruneTimer = setInterval(() => {
+                this._lru.prune()
             }, parameters.pruneTimerPeriod * 1000)
             if (this._lru.pruneTimer.unref) {
                 this._lru.pruneTimer.unref()
@@ -347,7 +345,6 @@ class CoAPServer extends events.EventEmitter {
         const sock = this._sock
         const lru = this._lru
         let Message = OutMessage
-        const that = this
         const request = new IncomingMessage(packet, rsinfo)
         const cached = lru.peek(this._toKey(request, packet, true))
 
@@ -376,8 +373,8 @@ class CoAPServer extends events.EventEmitter {
         const cacheKey = this._toCacheKey(request, packet)
 
         packet.piggybackReplyMs = this._options.piggybackReplyMs
-        const generateResponse = function () {
-            const response = new Message(packet, function (response, packet) {
+        const generateResponse = () => {
+            const response = new Message(packet, (response, packet) => {
                 let buf
                 const sender = new RetrySend(sock, rsinfo.port, rsinfo.address)
 
@@ -395,7 +392,7 @@ class CoAPServer extends events.EventEmitter {
                     })
                 }
 
-                const key = that._toKey(
+                const key = this._toKey(
                     request,
                     packet,
                     packet.ack || !packet.confirmable
@@ -404,7 +401,7 @@ class CoAPServer extends events.EventEmitter {
                 buf.sender = sender
 
                 if (
-                    that._options.sendAcksForNonConfirmablePackets ||
+                    this._options.sendAcksForNonConfirmablePackets ||
                     packet.confirmable
                 ) {
                     sender.send(
@@ -421,7 +418,7 @@ class CoAPServer extends events.EventEmitter {
             response._cachekey = cacheKey
 
             // inject this function so the response can add an entry to the cache
-            response._addCacheEntry = that._block2Cache.add.bind(that._block2Cache)
+            response._addCacheEntry = this._block2Cache.add.bind(this._block2Cache)
 
             return response
         }
@@ -558,8 +555,6 @@ class OutMessage extends OutgoingMessage {
      * @param {Buffer} payload A buffer-like object containing data to send back to the client.
      */
     end (payload) {
-        const that = this
-
         // removeOption(this._request.options, 'Block1');
         // add logic for Block1 sending
 
@@ -570,7 +565,7 @@ class OutMessage extends OutgoingMessage {
             requestedBlockOption = parseBlock2(block2Buff)
             // bad option
             if (!requestedBlockOption) {
-                that.statusCode = '4.02'
+                this.statusCode = '4.02'
                 return super.end()
             }
         }
@@ -599,7 +594,7 @@ class OutMessage extends OutgoingMessage {
             Math.ceil(payload.length / requestedBlockOption.size) - 1
         if (requestedBlockOption.num > lastBlockNum) {
             // precondition fail, may request for out of range block
-            that.statusCode = '4.02'
+            this.statusCode = '4.02'
             return super.end()
         }
         // check if requested block is the last
@@ -613,7 +608,7 @@ class OutMessage extends OutgoingMessage {
         if (!block2) {
             // this catch never be match,
             // since we're gentleman, just handle it
-            that.statusCode = '4.02'
+            this.statusCode = '4.02'
             super.end()
         }
         this.setOption('Block2', block2)


### PR DESCRIPTION
This PR removes the

```js
const that = this
```

statements from the codebase and replaces occurences of `that` with `this` by using arrow functions which allow for calling `this` directly. This should make the code easier to read.