### PR TITLE
refactor: replace unneeded `function` statements with arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ CoAP message to it:
 const coap = require('coap')
 const server = coap.createServer()
 
-server.on('request', function (req, res) {
+server.on('request', (req, res) => {
   res.end('Hello ' + req.url.split('/')[1] + '\n')
 })
 
 // the default CoAP port is 5683
-server.listen(function () {
+server.listen(() => {
   const req = coap.request('coap://localhost/Matteo')
 
-  req.on('response', function (res) {
+  req.on('response', (res) => {
     res.pipe(process.stdout)
-    res.on('end', function () {
+    res.on('end', () => {
       process.exit(0)
     })
   })
@@ -84,17 +84,17 @@ or on IPv6:
 const coap = require('coap')
 const server = coap.createServer({ type: 'udp6' })
 
-server.on('request', function(req, res) {
+server.on('request', (req, res) => {
   res.end('Hello ' + req.url.split('/')[1] + '\n')
 })
 
 // the default CoAP port is 5683
-server.listen(function() {
+server.listen(() => {
   const req = coap.request('coap://[::1]/Matteo')
 
-  req.on('response', function(res) {
+  req.on('response', (res) => {
     res.pipe(process.stdout)
-    res.on('end', function() {
+    res.on('end', () => {
       process.exit(0)
     })
   })

--- a/examples/blockwise.js
+++ b/examples/blockwise.js
@@ -1,21 +1,21 @@
 const coap = require('../') // or coap
 const url = require('url')
 
-coap.createServer(function (req, res) {
+coap.createServer((req, res) => {
     const path = url.parse(req.url) // eslint-disable-line node/no-deprecated-api
     const time = parseInt(path.search.split('=')[1])
     const pathname = path.pathname.split('/')[1]
 
     res.end(new Array(time + 1).join(pathname + ' '))
-}).listen(function () {
+}).listen(() => {
     const req = coap.request('coap://localhost/repeat-me?t=400')
 
     // edit this to adjust max packet
     req.setOption('Block2', Buffer.of(0x2))
 
-    req.on('response', function (res) {
+    req.on('response', (res) => {
         res.pipe(process.stdout)
-        res.on('end', function () {
+        res.on('end', () => {
             process.exit(0)
         })
     })

--- a/examples/blockwise_put.js
+++ b/examples/blockwise_put.js
@@ -20,16 +20,16 @@ testBuffer.write(containedData, testBuffer.length - containedData.length, contai
  * Tests the GET Block2 method transfer. Sends data in 1024 byte chunks
 */
 function TestGet () { // eslint-disable-line no-unused-vars
-    coap.createServer(function (req, res) {
+    coap.createServer((req, res) => {
     // Respond with the test buffer.
         res.end(testBuffer)
-    }).listen(function () {
+    }).listen(() => {
     // GET Request resources /test with block transfer with 1024 byte size
         const req = coap.request('/test')
 
         req.setOption('Block2', Buffer.from(0x6))
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             console.log('Client Received ' + res.payload.length + ' bytes')
             process.exit(0)
         })
@@ -41,7 +41,7 @@ function TestGet () { // eslint-disable-line no-unused-vars
  * Tests the PUT Block1 method transfer. Sends data in 1024 byte chunks
 */
 function TestPut () {
-    coap.createServer(function (req, res) {
+    coap.createServer((req, res) => {
         setTimeout(() => {
             console.log('Server Received ' + req.payload.length + ' bytes')
             console.log(req.payload.slice(0, containedData.length * 2).toString('utf-8'))
@@ -51,7 +51,7 @@ function TestPut () {
             res.end('Congratulations!')
             console.log('Sent back')
         }, 500)
-    }).listen(function () {
+    }).listen(() => {
         const request = coap.request({
             hostname: this.hostname,
             port: this.port,
@@ -60,7 +60,7 @@ function TestPut () {
         })
         request.setOption('Block1', Buffer.from(0x6))
 
-        request.on('response', function (res) {
+        request.on('response', (res) => {
             console.log('Client Received Response: ' + res.payload.toString('utf-8'))
             console.log('Client Received Response: ' + res.code)
             process.exit(0)
@@ -75,7 +75,7 @@ function TestPut () {
  * Start up an external CoAP client and try it out.
 */
 function TestServer () { // eslint-disable-line no-unused-vars
-    coap.createServer(function (req, res) {
+    coap.createServer((req, res) => {
         console.log('Got request. Waiting 500ms')
         setTimeout(() => {
             res.setOption('Block2', Buffer.from(0x6))
@@ -98,7 +98,7 @@ function TestClient () { // eslint-disable-line no-unused-vars
     })
     request.setOption('Block1', Buffer.from(0))
 
-    request.on('response', function (res) {
+    request.on('response', (res) => {
         console.log('Client Received ' + res.payload.length + ' bytes in response')
         process.exit(0)
     })

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,7 +1,7 @@
 const coap = require('../') // or coap
 const req = coap.request('coap://localhost/Matteo')
 
-req.on('response', function (res) {
+req.on('response', (res) => {
     res.pipe(process.stdout)
 })
 

--- a/examples/client_and_server.js
+++ b/examples/client_and_server.js
@@ -1,13 +1,13 @@
 const coap = require('../') // or coap
 
-coap.createServer(function (req, res) {
+coap.createServer((req, res) => {
     res.end('Hello ' + req.url.split('/')[1] + '\n')
-}).listen(function () {
+}).listen(() => {
     const req = coap.request('coap://localhost/Matteo')
 
-    req.on('response', function (res) {
+    req.on('response', (res) => {
         res.pipe(process.stdout)
-        res.on('end', function () {
+        res.on('end', () => {
             process.exit(0)
         })
     })

--- a/examples/delayed_response.js
+++ b/examples/delayed_response.js
@@ -1,12 +1,12 @@
 const coap = require('../') // or coap
 
-coap.createServer(function (req, res) {
+coap.createServer((req, res) => {
     // simulate delayed response
-    setTimeout(function () {
+    setTimeout(() => {
         res.setOption('Block2', Buffer.of(2))
         res.end('Hello ' + req.url.split('/')[1] + '\nMessage payload:\n' + req.payload + '\n')
     }, 1500)
-}).listen(function () {
+}).listen(() => {
     const coapConnection = {
         host: 'localhost',
         pathname: '/yo',
@@ -16,9 +16,9 @@ coap.createServer(function (req, res) {
     const req = coap.request(coapConnection)
     req.write('<yo><randomnameofaxmlpayload1><value>182374238472637846278346827346827346827346827346827346782346287346872346283746283462837462873468273462873462387462387</value></randomnameofaxmlpayload1><randomnameofaxmlpayload2><value>182374238472637846278346827346827346827346827346827346782346287346872346283746283462837462873468273462873462387462387</value></randomnameofaxmlpayload2></yo>')
 
-    req.on('response', function (res) {
+    req.on('response', (res) => {
         res.pipe(process.stdout)
-        res.on('end', function () {
+        res.on('end', () => {
             process.exit(0)
         })
     })

--- a/examples/json.js
+++ b/examples/json.js
@@ -1,7 +1,7 @@
 const coap = require('../') // or coap
 const bl = require('bl')
 
-coap.createServer(function (req, res) {
+coap.createServer((req, res) => {
     if (req.headers.Accept !== 'application/json') {
         res.code = '4.06'
         return res.end()
@@ -10,20 +10,20 @@ coap.createServer(function (req, res) {
     res.setOption('Content-Format', 'application/json')
 
     res.end(JSON.stringify({ hello: 'world' }))
-}).listen(function () {
+}).listen(() => {
     coap
         .request({
             pathname: '/Matteo',
             options: {
             }
         })
-        .on('response', function (res) {
+        .on('response', (res) => {
             console.log('response code', res.code)
             if (res.code !== '2.05') {
                 return process.exit(1)
             }
 
-            res.pipe(bl(function (err, data) {
+            res.pipe(bl((err, data) => {
                 if (err) {
                     process.exit(1)
                 } else {

--- a/examples/multicast_client_server.js
+++ b/examples/multicast_client_server.js
@@ -7,22 +7,22 @@ const server2 = coap.createServer({
 })
 
 // Create servers
-server.listen(5683, function () {
+server.listen(5683, () => {
     console.log('Server 1 is listening')
 })
 
-server2.listen(5683, function () {
+server2.listen(5683, () => {
     console.log('Server 2 is listening')
 })
 
-server.on('request', function (msg, res) {
+server.on('request', (msg, res) => {
     console.log('Server 1 has received message')
     res.end('Ok')
 
     server.close()
 })
 
-server2.on('request', function (msg, res) {
+server2.on('request', (msg, res) => {
     console.log('Server 2 has received message')
     res.end('Ok')
 

--- a/examples/observe_client.js
+++ b/examples/observe_client.js
@@ -3,7 +3,7 @@ const req = coap.request({
     observe: true
 })
 
-req.on('response', function (res) {
+req.on('response', (res) => {
     res.pipe(process.stdout)
 })
 

--- a/examples/observe_server.js
+++ b/examples/observe_server.js
@@ -1,20 +1,20 @@
 const coap = require('../') // or coap
 const server = coap.createServer()
 
-server.on('request', function (req, res) {
+server.on('request', (req, res) => {
     if (req.headers.Observe !== 0) {
         return res.end(new Date().toISOString() + '\n')
     }
 
-    const interval = setInterval(function () {
+    const interval = setInterval(() => {
         res.write(new Date().toISOString() + '\n')
     }, 1000)
 
-    res.on('finish', function () {
+    res.on('finish', () => {
         clearInterval(interval)
     })
 })
 
-server.listen(function () {
+server.listen(() => {
     console.log('server started')
 })

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -37,7 +37,7 @@ function createProxy (callback) {
 }
 
 function sendRequest (proxied) {
-    return function (n, callback) {
+    return (n, callback) => {
         const req = {
             host: 'localhost',
             port: 8976,
@@ -52,7 +52,7 @@ function sendRequest (proxied) {
 
         const request = coap.request(req)
 
-        request.on('response', function (res) {
+        request.on('response', (res) => {
             console.log('Client receives [%s] in port [%s] from [%s]', res.payload, res.outSocket.port, res.rsinfo.port)
             callback()
         })
@@ -64,7 +64,7 @@ function sendRequest (proxied) {
 }
 
 function executeTest (proxied) {
-    return function (callback) {
+    return (callback) => {
         if (proxied) {
             console.log(formatTitle('Executing tests with proxy'))
         } else {
@@ -76,7 +76,7 @@ function executeTest (proxied) {
 }
 
 function cleanUp (callback) {
-    targetServer.close(function () {
+    targetServer.close(() => {
         proxy.close(callback)
     })
 }

--- a/examples/req_with_payload.js
+++ b/examples/req_with_payload.js
@@ -1,8 +1,8 @@
 const coap = require('../') // or coap
 
-coap.createServer(function (req, res) {
+coap.createServer((req, res) => {
     res.end('Hello ' + req.url.split('/')[1] + '\nMessage payload:\n' + req.payload + '\n')
-}).listen(function () {
+}).listen(() => {
     const req = coap.request('coap://localhost/Matteo')
 
     const payload = {
@@ -12,9 +12,9 @@ coap.createServer(function (req, res) {
 
     req.write(JSON.stringify(payload))
 
-    req.on('response', function (res) {
+    req.on('response', (res) => {
         res.pipe(process.stdout)
-        res.on('end', function () {
+        res.on('end', () => {
             process.exit(0)
         })
     })

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,10 +1,10 @@
 const coap = require('../') // or coap
 const server = coap.createServer()
 
-server.on('request', function (req, res) {
+server.on('request', (req, res) => {
     res.end('Hello ' + req.url.split('/')[1] + '\n')
 })
 
-server.listen(function () {
+server.listen(() => {
     console.log('server started')
 })

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const URL = require('url')
 const globalAgent = new Agent({ type: 'udp4' })
 const globalAgentV6 = new Agent({ type: 'udp6' })
 
-module.exports.request = function (url) {
+module.exports.request = (url) => {
     let agent
 
     if (typeof url === 'string') {
@@ -40,7 +40,7 @@ module.exports.request = function (url) {
     return agent.request(url)
 }
 
-module.exports.createServer = function (options, listener) {
+module.exports.createServer = (options, listener) => {
     return new Server(options, listener)
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -303,7 +303,7 @@ class Agent extends events.EventEmitter {
 
                 const deregisterReq = this.request(deregisterUrl)
                 // If the request fails, we'll deal with it with a RST message anyway.
-                deregisterReq.on('error', function () {})
+                deregisterReq.on('error', () => {})
                 deregisterReq.end()
             })
         } else {
@@ -486,8 +486,8 @@ class Agent extends events.EventEmitter {
     urlPropertyToPacketOption (url, req, property, option, separator) {
         if (url[property]) {
             req.setOption(option, url[property].normalize('NFC').split(separator)
-                .filter(function (part) { return part !== '' })
-                .map(function (part) {
+                .filter((part) => { return part !== '' })
+                .map((part) => {
                     const buf = Buffer.alloc(Buffer.byteLength(part))
                     buf.write(part)
                     return buf

--- a/lib/block.js
+++ b/lib/block.js
@@ -13,7 +13,7 @@ const TwoPowTwenty = 1048575
  * @param {Boolean} moreBlocks If there are more blocks to follow
  * @param {Number} blockSize
  */
-module.exports.generateBlockOption = function (sequenceNumber, moreBlocks, blockSize) {
+module.exports.generateBlockOption = (sequenceNumber, moreBlocks, blockSize) => {
     if (typeof sequenceNumber === 'object') {
         moreBlocks = sequenceNumber.moreBlocks
         blockSize = sequenceNumber.blockSize
@@ -44,7 +44,7 @@ module.exports.generateBlockOption = function (sequenceNumber, moreBlocks, block
     return buff
 }
 
-module.exports.parseBlockOption = function (buff) {
+module.exports.parseBlockOption = (buff) => {
     if (buff.length === 1) {
         buff = Buffer.concat([Buffer.alloc(3), buff])
     } else if (buff.length === 2) {
@@ -68,10 +68,10 @@ module.exports.parseBlockOption = function (buff) {
     }
 }
 
-module.exports.exponentToByteSize = function (expo) {
+module.exports.exponentToByteSize = (expo) => {
     return Math.pow(2, expo + 4)
 }
 
-module.exports.byteSizeToExponent = function (byteSize) {
+module.exports.byteSizeToExponent = (byteSize) => {
     return Math.round(Math.log(byteSize) / Math.log(2) - 4)
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,7 +19,7 @@ const codes = {
 const capitalize = require('capitalize')
 const isIgnored = require('./option_converter').isIgnored
 
-module.exports.genAck = function (request) {
+module.exports.genAck = (request) => {
     return {
         messageId: request.messageId,
         code: '0.00',
@@ -45,7 +45,7 @@ function setOption (name, values) {
         return this
     }
 
-    this._packet.options = this._packet.options.filter(function (option) {
+    this._packet.options = this._packet.options.filter((option) => {
         return option.name !== name
     })
 
@@ -63,13 +63,13 @@ function setOption (name, values) {
     return this
 }
 
-module.exports.addSetOption = function (klass) {
+module.exports.addSetOption = (klass) => {
     const proto = klass.prototype
     proto.setOption = setOption
     proto.setHeader = setOption
 }
 
-module.exports.toCode = function toCode (code) {
+module.exports.toCode = (code) => {
     if (typeof code === 'string') {
         return code
     }
@@ -89,7 +89,7 @@ module.exports.toCode = function toCode (code) {
     return result
 }
 
-module.exports.packetToMessage = function packetToMessage (dest, packet) {
+module.exports.packetToMessage = (dest, packet) => {
     let i
     const options = packet.options
     let option
@@ -132,7 +132,7 @@ module.exports.packetToMessage = function packetToMessage (dest, packet) {
     }
 }
 
-module.exports.hasOption = function hasOption (options, name) {
+module.exports.hasOption = (options, name) => {
     for (const i in options) {
         if (options[i].name === name) {
             return true
@@ -147,7 +147,7 @@ get an option value from options
   name        name of the object wanted to retrive
   return      value, or null
 */
-module.exports.getOption = function getOption (options, name) {
+module.exports.getOption = (options, name) => {
     for (const i in options) {
         if (options[i].name === name) {
             return options[i].value
@@ -162,7 +162,7 @@ get an option value from options
   name        name of the object wanted to retrive
   return      value, or null
 */
-module.exports.removeOption = function removeOption (options, name) {
+module.exports.removeOption = (options, name) => {
     for (const i in options) {
         if (options[i].name === name) {
             delete options[i]
@@ -172,7 +172,7 @@ module.exports.removeOption = function removeOption (options, name) {
     return false
 }
 
-module.exports.simplifyPacketForPrint = function simplifyPacketForPrint (packetIn) {
+module.exports.simplifyPacketForPrint = (packetIn) => {
     const packet = Object.assign({}, packetIn)
     packet.token = packet.token.toString('hex')
     packet.payload = 'Buff: ' + packet.payload.length
@@ -192,7 +192,7 @@ parse block2
 
 with invalid block2 value, the function return null
 */
-module.exports.parseBlock2 = function parseBlock2 (block2Value) {
+module.exports.parseBlock2 = (block2Value) => {
     let num
     switch (block2Value.length) {
     case 1:
@@ -225,7 +225,7 @@ create buffer for block2 option
   requestedBlock      object contain block2 infor, e.g. {moreBlock2: true, num: 100, size: 32}
   return              Buffer carrying block2 value
 */
-module.exports.createBlock2 = function createBlock2 (requestedBlock) {
+module.exports.createBlock2 = (requestedBlock) => {
     let byte
     const szx = Math.log(requestedBlock.size) / Math.log(2) - 4
     const m = ((requestedBlock.moreBlock2 === true) ? 1 : 0)
@@ -256,23 +256,23 @@ module.exports.createBlock2 = function createBlock2 (requestedBlock) {
 /**
  * Provide a or function to use with the reduce() Array method
  */
-module.exports.or = function or (previous, current) {
+module.exports.or = (previous, current) => {
     return previous || current
 }
 
 /**
  * Provide a function to detect whether an option has a particular name (for its use with filter or map).
  */
-module.exports.isOption = function isOption (optionName) {
-    return function (option) {
+module.exports.isOption = (optionName) => {
+    return (option) => {
         return option.name === optionName
     }
 }
 
-module.exports.isNumeric = function isNumeric (n) {
+module.exports.isNumeric = (n) => {
     return !isNaN(parseFloat(n)) && isFinite(n)
 }
 
-module.exports.isBoolean = function isBoolean (n) {
+module.exports.isBoolean = (n) => {
     return typeof (n) === 'boolean'
 }

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -15,7 +15,7 @@ const optionFromBinaryFunctions = {}
 // list of options silently ignored
 const ignoredOptions = {}
 
-module.exports.toBinary = function (name, value) {
+module.exports.toBinary = (name, value) => {
     if (Buffer.isBuffer(value)) {
         return value
     }
@@ -27,7 +27,7 @@ module.exports.toBinary = function (name, value) {
     return optionToBinaryFunctions[name](value)
 }
 
-module.exports.fromBinary = function (name, value) {
+module.exports.fromBinary = (name, value) => {
     const convert = optionFromBinaryFunctions[name]
 
     if (!convert) {
@@ -37,14 +37,14 @@ module.exports.fromBinary = function (name, value) {
     return convert(value)
 }
 
-const registerOption = function (name, toBinary, fromBinary) {
+const registerOption = (name, toBinary, fromBinary) => {
     optionFromBinaryFunctions[name] = fromBinary
     optionToBinaryFunctions[name] = toBinary
 }
 
 module.exports.registerOption = registerOption
 
-const ignoreOption = function (name) {
+const ignoreOption = (name) => {
     ignoredOptions[name] = true
 }
 
@@ -54,16 +54,16 @@ ignoreOption('Cache-Control')
 ignoreOption('Content-Length')
 ignoreOption('Accept-Ranges')
 
-module.exports.isIgnored = function (name) {
+module.exports.isIgnored = (name) => {
     return !!ignoredOptions[name]
 }
 
 // ETag option registration
-const fromString = function (result) {
+const fromString = (result) => {
     return Buffer.from(result)
 }
 
-const toString = function (value) {
+const toString = (value) => {
     return value.toString()
 }
 
@@ -72,7 +72,7 @@ registerOption('Location-Path', fromString, toString)
 registerOption('Location-Query', fromString, toString)
 registerOption('Proxy-Uri', fromString, toString)
 
-const fromUint = function (result) {
+const fromUint = (result) => {
     let uint = Number(result)
     if (!isFinite(uint) || Math.floor(uint) !== uint || uint < 0) {
         throw TypeError('Expected uint, got ' + result)
@@ -85,7 +85,7 @@ const fromUint = function (result) {
     return Buffer.from(parts)
 }
 
-const toUint = function (value) {
+const toUint = (value) => {
     let result = 0
     for (let i = 0; i < value.length; ++i) {
         result = 256 * result + value[i]
@@ -99,7 +99,7 @@ registerOption('Max-Age', fromUint, toUint)
 const formatsString = {}
 const formatsBinaries = {}
 
-const registerFormat = function (name, value) {
+const registerFormat = (name, value) => {
     let bytes
 
     if (value > 255) {
@@ -146,7 +146,7 @@ registerFormat('application/senml-etch+json', 320)
 registerFormat('application/senml-etch+cbor', 322)
 registerFormat('application/td+json', 432)
 
-const contentFormatToBinary = function (value) {
+function contentFormatToBinary (value) {
     const result = formatsString[value.split(';')[0]]
     if (!result) {
         throw new Error('Unknown Content-Format: ' + value)
@@ -155,7 +155,7 @@ const contentFormatToBinary = function (value) {
     return result
 }
 
-const contentFormatToString = function (value) {
+function contentFormatToString (value) {
     if (value.length === 0) {
         return formatsBinaries[0]
     }
@@ -179,7 +179,7 @@ const contentFormatToString = function (value) {
 
 registerOption('Content-Format', contentFormatToBinary, contentFormatToString)
 registerOption('Accept', contentFormatToBinary, contentFormatToString)
-registerOption('Observe', function (sequence) {
+registerOption('Observe', (sequence) => {
     let buf
 
     if (!sequence) {
@@ -193,7 +193,7 @@ registerOption('Observe', function (sequence) {
     }
 
     return buf
-}, function (buf) {
+}, (buf) => {
     let result = 0
 
     if (buf.length === 1) {

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -29,7 +29,7 @@ const p = {
 }
 const defaultTiming = JSON.parse(JSON.stringify(p))
 
-p.refreshTiming = function (values) {
+p.refreshTiming = (values) => {
     for (const key in values) {
         if (p[key]) {
             p[key] = values[key]
@@ -72,7 +72,7 @@ p.refreshTiming = function (values) {
 }
 p.refreshTiming()
 
-p.defaultTiming = function () {
+p.defaultTiming = () => {
     p.refreshTiming(defaultTiming)
 }
 

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -8,7 +8,7 @@
 * See the included LICENSE file for more details.
 */
 
-exports.compareBuffers = function (buf1, buf2) {
+exports.compareBuffers = (buf1, buf2) => {
     if (Buffer.compare) {
         return Buffer.compare(buf1, buf2)
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -61,7 +61,7 @@ function removeProxyOptions (packet) {
 }
 
 function handleRequest (server) {
-    return function (msg, rsinfo) {
+    return (msg, rsinfo) => {
         const request = {
             raw: msg,
             rsinfo: rsinfo,
@@ -86,7 +86,7 @@ function allAddresses (type) {
     const interfaces = os.networkInterfaces()
     for (const ifname in interfaces) {
         if (Object.prototype.hasOwnProperty.call(interfaces, ifname)) {
-            interfaces[ifname].forEach(function (a) {
+            interfaces[ifname].forEach((a) => {
                 if (a.family === family) {
                     addresses.push(a.address)
                 }
@@ -159,11 +159,11 @@ class CoAPServer extends events.EventEmitter {
 
         this._lru = new LRU({
             max,
-            length: function (n) {
+            length: (n) => {
                 return n.buffer.byteLength
             },
             maxAge: parameters.exchangeLifetime * 1000,
-            dispose: function (key, value) {
+            dispose: (key, value) => {
                 if (value.sender) value.sender.reset()
             }
         })
@@ -387,7 +387,7 @@ class CoAPServer extends events.EventEmitter {
                     sender.on('error', response.emit.bind(response, 'error'))
                 } else {
                     buf.response = response
-                    sender.on('error', function () {
+                    sender.on('error', () => {
                         response.end()
                     })
                 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -66,7 +66,7 @@ describe('Agent', function () {
         doReq()
         doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             if (firstRsinfo) {
                 expect(rsinfo.port).to.eql(firstRsinfo.port)
                 done()
@@ -84,7 +84,7 @@ describe('Agent', function () {
         agent._lastMessageId = Math.pow(2, 16) - 1
         doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             if (total === 2) {
                 // nothing to do
             } else if (total === 1) {
@@ -102,7 +102,7 @@ describe('Agent', function () {
         doReq()
         doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             if (firstToken) {
                 expect(packet.token).not.to.eql(firstToken)
@@ -119,7 +119,7 @@ describe('Agent', function () {
         doReq()
         doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             if (firstMessageId) {
                 expect(packet.messageId).not.to.eql(firstMessageId)
@@ -135,7 +135,7 @@ describe('Agent', function () {
         const req1 = doReq()
         const req2 = doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -148,13 +148,13 @@ describe('Agent', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req1.once('response', function (res) {
+        req1.once('response', (res) => {
             if (++responses === 2) {
                 done()
             }
         })
 
-        req2.once('response', function (res) {
+        req2.once('response', (res) => {
             if (++responses === 2) {
                 done()
             }
@@ -167,7 +167,7 @@ describe('Agent', function () {
         // it is needed to keep the agent open
         doReq()
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -183,7 +183,7 @@ describe('Agent', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             // fails if it emits 'response' twice
             done()
         })
@@ -195,7 +195,7 @@ describe('Agent', function () {
         // it is needed to keep the agent open
         doReq()
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -212,7 +212,7 @@ describe('Agent', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers['Content-Format']).to.equal(1542)
             done()
         })
@@ -224,7 +224,7 @@ describe('Agent', function () {
         // it is needed to keep the agent open
         doReq()
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -241,7 +241,7 @@ describe('Agent', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers['Content-Format']).to.equal(undefined)
             done()
         })
@@ -253,7 +253,7 @@ describe('Agent', function () {
         // it is needed to keep the agent open
         doReq(true)
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -270,7 +270,7 @@ describe('Agent', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             // fails if it emits 'response' twice
             done()
         })
@@ -280,7 +280,7 @@ describe('Agent', function () {
         let firstRsinfo
         const req = doReq()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -301,7 +301,7 @@ describe('Agent', function () {
             }
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             setImmediate(doReq)
         })
     })
@@ -311,7 +311,7 @@ describe('Agent', function () {
         doReq(true)
         let step = 0
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
 
             switch (++step) {
@@ -372,7 +372,7 @@ describe('Agent', function () {
                 confirmable: true
             }).end()
 
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const packet = parse(msg)
 
                 sendObserve({
@@ -404,7 +404,7 @@ describe('Agent', function () {
                 })
             })
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 // fails if it emits 'response' twice
                 done()
             })
@@ -420,7 +420,7 @@ describe('Agent', function () {
                 confirmable: true
             }).end()
 
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const packet = parse(msg)
 
                 sendObserve({
@@ -433,7 +433,7 @@ describe('Agent', function () {
                 })
             })
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 if (firstRsinfo) {
                     expect(rsinfo.port).not.to.eql(firstRsinfo.port)
                     done()
@@ -442,7 +442,7 @@ describe('Agent', function () {
                 }
             })
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 res.close()
 
                 setImmediate(doReq)

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -66,7 +66,7 @@ describe('blockwise2', function () {
         coap.request({
             port: port
         })
-            .on('response', function (res) {
+            .on('response', (res) => {
                 let blockwiseResponse = false
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -79,7 +79,7 @@ describe('blockwise2', function () {
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -88,7 +88,7 @@ describe('blockwise2', function () {
         coap.request({
             port: port
         })
-            .on('response', function (res) {
+            .on('response', (res) => {
                 let blockwiseResponse = false
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -101,7 +101,7 @@ describe('blockwise2', function () {
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -110,13 +110,13 @@ describe('blockwise2', function () {
         coap.request({
             port: port
         })
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(typeof res.headers.ETag).to.eql('string')
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -126,7 +126,7 @@ describe('blockwise2', function () {
             port: port
         })
             .setOption('Block2', Buffer.of(0x02))
-            .on('response', function (res) {
+            .on('response', (res) => {
                 let block2
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -140,7 +140,7 @@ describe('blockwise2', function () {
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -150,13 +150,13 @@ describe('blockwise2', function () {
             port: port
         })
             .setOption('Block2', Buffer.of(0x07)) // request for block 0, with overload size of 2**(7+4)
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.02')
                 // expect(cache.get(res._packet.token.toString())).to.be.undefined
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -169,13 +169,13 @@ describe('blockwise2', function () {
             port: port
         })
             .setOption('Block2', Buffer.of(0x3D)) // request for block index 3
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.02')
                 // expect(cache.get(res._packet.token.toString())).to.be.undefined
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -185,13 +185,13 @@ describe('blockwise2', function () {
             port: port
         })
             .setOption('Block2', Buffer.of(0x10)) // request from block 1, with size = 16
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.payload).to.eql(payload.slice(1 * 16, payload.length + 1))
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -202,13 +202,13 @@ describe('blockwise2', function () {
             port: port
         })
             .setOption('Block2', Buffer.of(0x0)) // early negotation with block size = 16, almost 10000/16 = 63 blocks
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.payload).to.eql(payload)
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)
             })
             .end()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(payload)
         })
     })
@@ -242,7 +242,7 @@ describe('blockwise2', function () {
         fillPayloadBuffer(req1Token)
 
         let nreq = 1
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             // only two request to upper level, blockwise transfer completed from cache
             if (nreq === 1) {
                 res.end(payloadReq1)
@@ -258,7 +258,7 @@ describe('blockwise2', function () {
         // Send first request, initiate blockwise transfer from server
         sendNextBlock2(req1Token, req1Block2Num)
 
-        client.on('message', function (msg, rinfo) {
+        client.on('message', (msg, rinfo) => {
             checkBlock2Message(msg, payloadReq1, req1Block2Num, payloadLength)
 
             const expectMore = (req1Block2Num + 1) * 16 <= payloadLength
@@ -266,7 +266,7 @@ describe('blockwise2', function () {
                 // Request next block after 50 msec delay
                 req1Block2Num++
 
-                setTimeout(function () {
+                setTimeout(() => {
                     // Send next request, fetch next block of blockwise transfer from server
                     sendNextBlock2(req1Token, req1Block2Num)
                 }, 50)
@@ -282,11 +282,11 @@ describe('blockwise2', function () {
         reqClient2.setOption('Block2', Buffer.of(0x10)) // request from block 1, with size = 16
 
         // Delay second request so that first request gets first packet
-        setTimeout(function () {
+        setTimeout(() => {
             reqClient2.end()
         }, 1)
 
-        reqClient2.on('response', function (res) {
+        reqClient2.on('response', (res) => {
             checkNormalReq(res, payloadReq2)
 
             req2Done = true
@@ -300,7 +300,7 @@ describe('blockwise2', function () {
     }
 
     it('should two parallel block2 requests should result only two requests to upper level', function (done) {
-        const checkNreq = function (nreq) {
+        const checkNreq = (nreq) => {
             expect(nreq).to.within(1, 2)
         }
 
@@ -308,14 +308,14 @@ describe('blockwise2', function () {
     })
 
     it('should have code 2.05 for all block2 messages of successful parallel requests', function (done) {
-        const checkBlock2Code = function (msg) {
+        const checkBlock2Code = (msg) => {
             const res = parse(msg)
 
             // Have correct code?
             expect(res.code).to.eql('2.05')
         }
 
-        const checkNormalRespCode = function (res) {
+        const checkNormalRespCode = (res) => {
             // Have correct code?
             expect(res.code).to.eql('2.05')
         }
@@ -324,7 +324,7 @@ describe('blockwise2', function () {
     })
 
     it('should have correct block2 option for parallel requests', function (done) {
-        const checkBlock2Option = function (msg, payloadReq1, req1Block2Num, payloadLength) {
+        const checkBlock2Option = (msg, payloadReq1, req1Block2Num, payloadLength) => {
             const res = parse(msg)
 
             // Have block2 option?
@@ -345,14 +345,14 @@ describe('blockwise2', function () {
     })
 
     it('should have correct payload in block2 messages for parallel requests', function (done) {
-        const checkBlock2Payload = function (msg, payloadReq1, req1Block2Num) {
+        const checkBlock2Payload = (msg, payloadReq1, req1Block2Num) => {
             const res = parse(msg)
 
             // Have correct payload?
             expect(res.payload).to.eql(payloadReq1.slice(req1Block2Num * 16, req1Block2Num * 16 + 16))
         }
 
-        const checkNormalRespPayload = function (res, payloadReq2) {
+        const checkNormalRespPayload = (res, payloadReq2) => {
             // Have correct payload?
             expect(res.payload).to.eql(payloadReq2.slice(1 * 16, payload.length + 1))
         }

--- a/test/common.js
+++ b/test/common.js
@@ -9,6 +9,6 @@
 global.expect = require('chai').expect
 
 let portCounter = 9042
-global.nextPort = function () {
+global.nextPort = () => {
     return ++portCounter
 }

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -25,13 +25,13 @@ describe('end-to-end', function () {
     server.on('error', function() {})
   }) */
 
-    process.on('uncaughtException', function (err) {
+    process.on('uncaughtException', (err) => {
         console.log('Caught exception: ' + err)
     })
 
     it('should receive a request at a path with some query', function (done) {
         coap.request('coap://localhost:' + port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.url).to.eql('/abcd/ef/gh?foo=bar&beep=bop')
             setImmediate(done)
         })
@@ -39,12 +39,12 @@ describe('end-to-end', function () {
 
     it('should return code 2.05 by default', function (done) {
         const req = coap.request('coap://localhost:' + port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('2.05')
             setImmediate(done)
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
         })
     })
@@ -52,13 +52,13 @@ describe('end-to-end', function () {
     it('should return code using res.code attribute', function (done) {
         coap
             .request('coap://localhost:' + port)
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.04')
                 setImmediate(done)
             })
             .end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.code = '4.04'
             res.end('hello')
         })
@@ -67,13 +67,13 @@ describe('end-to-end', function () {
     it('should return code using res.statusCode attribute', function (done) {
         coap
             .request('coap://localhost:' + port)
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.04')
                 setImmediate(done)
             })
             .end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end('hello')
         })
@@ -85,17 +85,17 @@ describe('end-to-end', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
-            res.once('data', function (data) {
+        req.on('response', (res) => {
+            res.once('data', (data) => {
                 expect(data.toString()).to.eql('hello')
-                res.once('data', function (data) {
+                res.once('data', (data) => {
                     expect(data.toString()).to.eql('world')
                     done()
                 })
             })
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.write('hello')
             res.end('world')
         })
@@ -107,12 +107,12 @@ describe('end-to-end', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('4.04')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end()
         })
@@ -124,13 +124,13 @@ describe('end-to-end', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('4.04')
             res.on('end', done)
             res.resume()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end()
         })
@@ -144,7 +144,7 @@ describe('end-to-end', function () {
             pathname: '/\u210e/\u0065\u0301'
         }).end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req.url).to.equal('/\u210e/\u00e9')
             done()
             res.end()
@@ -163,7 +163,7 @@ describe('end-to-end', function () {
                     req.setOption(option, format)
                     req.end()
 
-                    server.once('request', function (req) {
+                    server.once('request', (req) => {
                         expect(req.options[0].name).to.eql(option)
                         expect(req.options[0].value).to.eql(format)
                         done()
@@ -180,7 +180,7 @@ describe('end-to-end', function () {
 
                     coap.request(req).end()
 
-                    server.once('request', function (req) {
+                    server.once('request', (req) => {
                         expect(req.options[0].name).to.eql(option)
                         expect(req.options[0].value).to.eql(format)
                         done()
@@ -197,7 +197,7 @@ describe('end-to-end', function () {
 
                     coap.request(req).end()
 
-                    server.once('request', function (req) {
+                    server.once('request', (req) => {
                         expect(req.headers[option]).to.eql(format)
                         done()
                     })
@@ -208,7 +208,7 @@ describe('end-to-end', function () {
                     req.setOption(option, format)
                     req.end()
 
-                    server.once('request', function (req) {
+                    server.once('request', (req) => {
                         expect(req.headers[option]).to.eql(format)
                         done()
                     })
@@ -221,12 +221,12 @@ describe('end-to-end', function () {
                 const req = coap.request('coap://localhost:' + port)
                 req.end()
 
-                server.once('request', function (req, res) {
+                server.once('request', (req, res) => {
                     res.setOption('Content-Format', format)
                     res.end()
                 })
 
-                req.on('response', function (res) {
+                req.on('response', (res) => {
                     expect(res.headers['Content-Format']).to.eql(format)
                     done()
                 })
@@ -240,7 +240,7 @@ describe('end-to-end', function () {
         req.setOption('Content-Format', 'application/json; charset=utf8')
         req.end()
 
-        server.once('request', function (req) {
+        server.once('request', (req) => {
             expect(req.options[0].name).to.equal('Content-Format')
             expect(req.options[0].value).to.equal('application/json')
             done()
@@ -253,7 +253,7 @@ describe('end-to-end', function () {
         req.setOption('Max-Age', 26763)
         req.end()
 
-        server.once('request', function (req) {
+        server.once('request', (req) => {
             expect(req.options[0].name).to.equal('Max-Age')
             expect(req.options[0].value).to.equal(26763)
             done()
@@ -263,12 +263,12 @@ describe('end-to-end', function () {
     it('should provide a writeHead() method', function (done) {
         const req = coap.request('coap://localhost:' + port)
         req.end()
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers['Content-Format']).to.equal('application/json')
             done()
         })
 
-        server.once('request', function (req, res) {
+        server.once('request', (req, res) => {
             res.writeHead(200, { 'Content-Format': 'application/json' })
             res.write(JSON.stringify({}))
             res.end()
@@ -281,12 +281,12 @@ describe('end-to-end', function () {
             method: 'PUT'
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers).to.have.property('Location-Path', '/hello')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.setOption('Location-Path', '/hello')
             res.end('hello')
         })
@@ -298,12 +298,12 @@ describe('end-to-end', function () {
             method: 'PUT'
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers).to.have.property('Location-Query', 'a=b')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.setOption('Location-Query', 'a=b')
             res.end('hello')
         })
@@ -324,17 +324,17 @@ describe('end-to-end', function () {
         }).end()
         let completed = 2
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.write('hello')
-            setTimeout(function () {
+            setTimeout(() => {
                 res.end('world')
             }, 10)
         })
 
-        ;[req1, req2].forEach(function (req) {
+        ;[req1, req2].forEach((req) => {
             let local = 2
-            req.on('response', function (res) {
-                res.on('data', function (data) {
+            req.on('response', (res) => {
+                res.on('data', (data) => {
                     if (--local === 0) {
                         --completed
                     }
@@ -360,7 +360,7 @@ describe('end-to-end', function () {
         }).end()
         let first
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             if (!first) {
                 first = req.rsinfo
@@ -381,7 +381,7 @@ describe('end-to-end', function () {
         }).end()
         let first
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             if (!first) {
                 first = req.rsinfo
@@ -391,8 +391,8 @@ describe('end-to-end', function () {
             }
         })
 
-        req1.on('response', function () {
-            setImmediate(function () {
+        req1.on('response', () => {
+            setImmediate(() => {
                 coap.request({
                     port: port,
                     method: 'GET',
@@ -411,7 +411,7 @@ describe('end-to-end', function () {
             agent: agent
         }).end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             expect(req.rsinfo.port).eql(3636)
             done()
@@ -423,7 +423,7 @@ describe('end-to-end', function () {
         req.setOption('Cache-Control', 'private')
         req.end()
 
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.headers).not.to.have.property('Cache-Control')
             done()
         })

--- a/test/ipv6.js
+++ b/test/ipv6.js
@@ -38,9 +38,9 @@ describe('IPv6', function () {
 
         it('should receive a CoAP message specifying the type', function (done) {
             server = coap.createServer({ type: 'udp6' })
-            server.listen(port, function () {
+            server.listen(port, () => {
                 send(generate())
-                server.on('request', function (req, res) {
+                server.on('request', (req, res) => {
                     done()
                 })
             })
@@ -48,9 +48,9 @@ describe('IPv6', function () {
 
         it('should automatically discover the type based on the host', function (done) {
             server = coap.createServer()
-            server.listen(port, '::1', function () {
+            server.listen(port, '::1', () => {
                 send(generate())
-                server.on('request', function (req, res) {
+                server.on('request', (req, res) => {
                     done()
                 })
             })
@@ -78,7 +78,7 @@ describe('IPv6', function () {
                 const req = coap.request(createUrl())
                 req.end(Buffer.from('hello world'))
 
-                server.on('message', function (msg, rsinfo) {
+                server.on('message', (msg, rsinfo) => {
                     const packet = parse(msg)
                     const toSend = generate({
                         messageId: packet.messageId,
@@ -120,7 +120,7 @@ describe('IPv6', function () {
 
         it('should receive a request at a path with some query', function (done) {
             coap.request('coap://[::1]:' + port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
-            server.on('request', function (req) {
+            server.on('request', (req) => {
                 expect(req.url).to.eql('/abcd/ef/gh?foo=bar&beep=bop')
                 done()
             })

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -31,13 +31,13 @@ describe('proxy', function () {
         server = coap.createServer({
             proxy: true
         })
-        server.listen(port, function () {
+        server.listen(port, () => {
             clientPort = nextPort()
             client = dgram.createSocket('udp4')
             targetPort = nextPort()
             target = coap.createServer()
 
-            client.bind(clientPort, function () {
+            client.bind(clientPort, () => {
                 target.listen(targetPort, done)
             })
         })
@@ -55,9 +55,9 @@ describe('proxy', function () {
 
         clock.restore()
 
-        closeSocket(client, function () {
-            closeSocket(server, function () {
-                closeSocket(target, function () {
+        closeSocket(client, () => {
+            closeSocket(server, () => {
+                closeSocket(target, () => {
                     tk.reset()
                     done()
                 })
@@ -77,7 +77,7 @@ describe('proxy', function () {
             }]
         }))
 
-        target.on('request', function (req, res) {
+        target.on('request', (req, res) => {
             done()
         })
     })
@@ -88,11 +88,11 @@ describe('proxy', function () {
         clock.restore()
 
         function sendObservation (message) {
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 res.setOption('Observe', 1)
                 res.write('Pruebas')
 
-                setTimeout(function () {
+                setTimeout(() => {
                     res.write('Pruebas2')
                     res.end('Last msg')
                 }, 500)
@@ -107,8 +107,8 @@ describe('proxy', function () {
 
         const req = sendObservation()
 
-        req.on('response', function (res) {
-            res.on('data', function (msg) {
+        req.on('response', (res) => {
+            res.on('data', (msg) => {
                 if (counter === 2) {
                     done()
                 } else {
@@ -121,11 +121,11 @@ describe('proxy', function () {
     })
 
     it('should not process the request as a standard server request', function (done) {
-        target.on('request', function (req, res) {
+        target.on('request', (req, res) => {
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
         })
 
         send(generate({
@@ -144,11 +144,11 @@ describe('proxy', function () {
             }]
         }))
 
-        target.on('request', function (req, res) {
+        target.on('request', (req, res) => {
             res.end('The response')
         })
 
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             const packet = parse(msg)
             expect(packet.payload.toString()).to.eql('The response')
             done()
@@ -164,7 +164,7 @@ describe('proxy', function () {
                 query: 'a=b'
             })
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 done()
             })
 
@@ -178,11 +178,11 @@ describe('proxy', function () {
                 query: 'a=b'
             })
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 res.end('This is the response')
             })
 
-            request.on('response', function (res) {
+            request.on('response', (res) => {
                 expect(res.payload.toString()).to.eql('This is the response')
                 done()
             })
@@ -201,15 +201,14 @@ describe('proxy', function () {
                 query: 'a=b'
             })
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 console.log('should not get here')
             })
 
-            server.on('error', function (req, res) {
-            })
+            server.on('error', (req, res) => {})
 
             request
-                .on('response', function (res) {
+                .on('response', (res) => {
                     try {
                         expect(res.code).to.eql('5.00')
                         expect(res.payload.toString()).to.match(/ENOTFOUND|EAI_AGAIN/)
@@ -230,16 +229,16 @@ describe('proxy', function () {
                 query: 'a=b'
             })
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 console.log('should not get here')
             })
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('Standard response')
             })
 
             request
-                .on('response', function (res) {
+                .on('response', (res) => {
                     expect(res.payload.toString()).to.contain('Standard response')
                     done()
                 })
@@ -256,16 +255,16 @@ describe('proxy', function () {
                 query: 'a=b'
             })
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 console.log('should not get here')
             })
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('Standard response')
             })
 
             request
-                .on('response', function (res) {
+                .on('response', (res) => {
                     expect(res.payload.toString()).to.contain('Standard response')
                     done()
                 })
@@ -280,23 +279,23 @@ describe('proxy', function () {
             })
             let count = 0
 
-            target.on('request', function (req, res) {
+            target.on('request', (req, res) => {
                 console.log('should not get here')
             })
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('Observe', 1)
                 res.write('This is the first response')
 
-                setTimeout(function () {
+                setTimeout(() => {
                     res.setOption('Observe', 1)
                     res.write('And this is the second')
                 }, 200)
             })
 
             request
-                .on('response', function (res) {
-                    res.on('data', function (chunk) {
+                .on('response', (res) => {
+                    res.on('data', (chunk) => {
                         count++
 
                         if (count === 1) {

--- a/test/request.js
+++ b/test/request.js
@@ -75,7 +75,7 @@ describe('request', function () {
         const req = request('coap://localhost:' + port)
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
             expect(parse(msg).payload.toString()).to.eql('hello world')
             done()
@@ -86,7 +86,7 @@ describe('request', function () {
         const req = request('coap://localhost:' + port)
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
             expect(parse(msg).confirmable).to.be.true // eslint-disable-line no-unused-expressions
             done()
@@ -97,7 +97,7 @@ describe('request', function () {
         this.timeout(20000)
         const req = request('coap://aaa.eee:' + 1234)
 
-        req.once('error', function () {
+        req.once('error', () => {
             coap.globalAgent.abort(req)
             done()
         })
@@ -108,7 +108,7 @@ describe('request', function () {
     it('should error if the message is too big', function (done) {
         const req = request('coap://localhost:' + port)
 
-        req.on('error', function () {
+        req.on('error', () => {
             done()
         })
 
@@ -118,11 +118,11 @@ describe('request', function () {
     it('should imply a default port', function (done) {
         server2 = dgram.createSocket('udp4')
 
-        server2.bind(5683, function () {
+        server2.bind(5683, () => {
             request('coap://localhost').end()
         })
 
-        server2.on('message', function (msg, rsinfo) {
+        server2.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
             done()
         })
@@ -132,7 +132,7 @@ describe('request', function () {
         const req = request('coap://localhost:' + port + '/hello')
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
 
             const packet = parse(msg)
@@ -147,7 +147,7 @@ describe('request', function () {
         const req = request('coap://localhost:' + port + '/hello/world')
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
 
             const packet = parse(msg)
@@ -168,7 +168,7 @@ describe('request', function () {
 
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
 
             const packet = parse(msg)
@@ -184,7 +184,7 @@ describe('request', function () {
         const req = request('coap://localhost:' + port + '?a=b&c=d')
         req.end(Buffer.from('hello world'))
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
 
             const packet = parse(msg)
@@ -202,7 +202,7 @@ describe('request', function () {
             method: 'POST'
         }).end()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
 
             const packet = parse(msg)
@@ -217,7 +217,7 @@ describe('request', function () {
             token: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])
         }).end()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             try {
                 ackBack(msg, rsinfo)
 
@@ -236,7 +236,7 @@ describe('request', function () {
             token: Buffer.from([])
         }).end()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             try {
                 ackBack(msg, rsinfo)
 
@@ -255,7 +255,7 @@ describe('request', function () {
             token: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         })
 
-        rq.on('error', function (err) {
+        rq.on('error', (err) => {
             if (err.message === 'Token may be no longer than 8 bytes.') {
                 // Success, this is what we were expecting
                 done()
@@ -267,7 +267,7 @@ describe('request', function () {
 
         rq.end()
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             // We should not see this!
             ackBack(msg, rsinfo)
             done(new Error('Message should not have been sent!'))
@@ -280,7 +280,7 @@ describe('request', function () {
             confirmable: true
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -292,8 +292,8 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
-            res.pipe(bl(function (err, data) {
+        req.on('response', (res) => {
+            res.pipe(bl((err, data) => {
                 if (err) {
                     done(err)
                 } else {
@@ -312,7 +312,7 @@ describe('request', function () {
             confirmable: true
         })
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             let toSend = generate({
                 messageId: packet.messageId,
@@ -332,8 +332,8 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
-            res.pipe(bl(function (err, data) {
+        req.on('response', (res) => {
+            res.pipe(bl((err, data) => {
                 if (err) {
                     done(err)
                 } else {
@@ -352,7 +352,7 @@ describe('request', function () {
             confirmable: true
         })
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             let packet = parse(msg)
             let toSend = generate({
                 messageId: packet.messageId,
@@ -370,7 +370,7 @@ describe('request', function () {
 
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
 
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 packet = parse(msg)
                 expect(packet.code).to.eql('0.00')
                 expect(packet.ack).to.be.true // eslint-disable-line no-unused-expressions
@@ -388,15 +388,15 @@ describe('request', function () {
             confirmable: true
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             ackBack(msg, rsinfo)
-            setTimeout(function () {
+            setTimeout(() => {
                 done()
             }, 20)
             fastForward(5, 25)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             done(new Error('Unexpected response'))
         })
 
@@ -409,7 +409,7 @@ describe('request', function () {
             confirmable: false
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -420,8 +420,8 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
-            res.pipe(bl(function (err, data) {
+        req.on('response', (res) => {
+            res.pipe(bl((err, data) => {
                 if (err) {
                     done(err)
                 }
@@ -438,7 +438,7 @@ describe('request', function () {
             port: port
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -449,7 +449,7 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             if (res.code === '0.00') {
                 done()
             } else {
@@ -466,7 +466,7 @@ describe('request', function () {
         })
         let messages = 0
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -478,14 +478,14 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             if (res.code !== '0.00') {
                 done(new Error('Unexpected response'))
             }
         })
         req.end()
 
-        setTimeout(function () {
+        setTimeout(() => {
             expect(messages).to.eql(1)
             done()
         }, 45 * 1000)
@@ -499,7 +499,7 @@ describe('request', function () {
         })
         let messages = 0
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -512,13 +512,13 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             done(new Error('Unexpected response'))
         })
 
         req.end()
 
-        setTimeout(function () {
+        setTimeout(() => {
             expect(messages).to.eql(5)
             done()
         }, 45 * 1000)
@@ -535,7 +535,7 @@ describe('request', function () {
         req.setOption('ETag', buf)
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].name).to.eql('ETag')
             expect(parse(msg).options[0].value).to.eql(buf)
             done()
@@ -551,7 +551,7 @@ describe('request', function () {
         req.setOption('content-type', buf)
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].name).to.eql('Content-Format')
             expect(parse(msg).options[0].value).to.eql(buf)
             done()
@@ -568,7 +568,7 @@ describe('request', function () {
         req.setOption('ETag', buf)
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].value).to.eql(buf)
             done()
         })
@@ -583,7 +583,7 @@ describe('request', function () {
         req.setHeader('ETag', buf)
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].value).to.eql(buf)
             done()
         })
@@ -599,7 +599,7 @@ describe('request', function () {
         req.setOption('433', [buf1, buf2])
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].value).to.eql(buf1)
             expect(parse(msg).options[1].value).to.eql(buf2)
             done()
@@ -614,7 +614,7 @@ describe('request', function () {
         req.setOption('Content-Type', Buffer.of(0))
         req.end()
 
-        server.on('message', function (msg) {
+        server.on('message', (msg) => {
             expect(parse(msg).options[0].name).to.eql('Content-Format')
             expect(parse(msg).options[0].value).to.eql(Buffer.of(0))
             done()
@@ -627,7 +627,7 @@ describe('request', function () {
             confirmable: true
         })
 
-        server.once('message', function (msg, rsinfo) {
+        server.once('message', (msg, rsinfo) => {
             const packet = parse(msg)
             let toSend = generate({
                 token: packet.token,
@@ -648,8 +648,8 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
-            res.pipe(bl(function (err, data) {
+        req.on('response', (res) => {
+            res.pipe(bl((err, data) => {
                 if (err) {
                     done(err)
                 } else {
@@ -682,7 +682,7 @@ describe('request', function () {
                 req.setOption('Content-Format', format)
                 req.end()
 
-                server.on('message', function (msg) {
+                server.on('message', (msg) => {
                     expect(parse(msg).options[0].value).to.eql(value)
                     done()
                 })
@@ -704,7 +704,7 @@ describe('request', function () {
                 req.setHeader('Accept', format)
                 req.end()
 
-                server.on('message', function (msg) {
+                server.on('message', (msg) => {
                     expect(parse(msg).options[0].value).to.eql(value)
                     done()
                 })
@@ -718,7 +718,7 @@ describe('request', function () {
 
     describe('with the \'Content-Format\' in the response', function () {
         function buildResponse (value) {
-            return function (msg, rsinfo) {
+            return (msg, rsinfo) => {
                 const packet = parse(msg)
                 const toSend = generate({
                     messageId: packet.messageId,
@@ -741,7 +741,7 @@ describe('request', function () {
 
                 server.on('message', buildResponse(value))
 
-                req.on('response', function (res) {
+                req.on('response', (res) => {
                     expect(res.options[0].value).to.eql(format)
                     done()
                 })
@@ -756,7 +756,7 @@ describe('request', function () {
 
                 server.on('message', buildResponse(value))
 
-                req.on('response', function (res) {
+                req.on('response', (res) => {
                     expect(res.headers['Content-Format']).to.eql(format)
                     expect(res.headers['Content-Type']).to.eql(format)
                     done()
@@ -776,7 +776,7 @@ describe('request', function () {
             port: port
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -790,7 +790,7 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers).to.have.property('ETag', 'abcdefgh')
             done()
         })
@@ -803,7 +803,7 @@ describe('request', function () {
             port: port
         })
 
-        server.on('message', function (msg, rsinfo) {
+        server.on('message', (msg, rsinfo) => {
             const packet = parse(msg)
             const toSend = generate({
                 messageId: packet.messageId,
@@ -814,7 +814,7 @@ describe('request', function () {
             server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
         })
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res).to.have.property('rsinfo')
             expect(res).to.have.property('outSocket')
             expect(res.outSocket).to.have.property('address')
@@ -853,10 +853,10 @@ describe('request', function () {
         it('should timeout after ~202 seconds', function (done) {
             const req = doReq()
 
-            req.on('error', function () {
+            req.on('error', () => {
             })
 
-            req.on('timeout', function (err) {
+            req.on('timeout', (err) => {
                 expect(err).to.have.property('message', 'No reply in 202s')
                 expect(err).to.have.property('retransmitTimeout', 202)
                 done()
@@ -869,11 +869,11 @@ describe('request', function () {
             const req = doReq()
             let messages = 0
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 messages++
             })
 
-            req.on('timeout', function () {
+            req.on('timeout', () => {
                 expect(messages).to.eql(1)
                 done()
             })
@@ -885,11 +885,11 @@ describe('request', function () {
             doReq()
             let messages = 0
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 messages++
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -901,7 +901,7 @@ describe('request', function () {
             doReq()
             let messages = 0
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 messages++
                 const packet = parse(msg)
                 const toSend = generate({
@@ -915,7 +915,7 @@ describe('request', function () {
                 server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -952,7 +952,7 @@ describe('request', function () {
         it('should error after ~247 seconds', function (done) {
             const req = doReq()
 
-            req.on('error', function (err) {
+            req.on('error', (err) => {
                 expect(err).to.have.property('message', 'No reply in 247s')
                 done()
             })
@@ -964,11 +964,11 @@ describe('request', function () {
             const req = doReq()
             let messages = 0
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 messages++
             })
 
-            req.on('error', function () {
+            req.on('error', () => {
                 // original one plus 4 retries
                 expect(messages).to.eql(5)
                 done()
@@ -981,7 +981,7 @@ describe('request', function () {
             const req = doReq()
             let messageId
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 const packet = parse(msg)
 
                 if (!messageId) {
@@ -991,7 +991,7 @@ describe('request', function () {
                 expect(packet.messageId).to.eql(messageId)
             })
 
-            req.on('error', function () {
+            req.on('error', () => {
                 done()
             })
 
@@ -1002,11 +1002,11 @@ describe('request', function () {
             doReq()
             let messages = 0
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 messages++
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 // original one plus 4 retries
                 expect(messages).to.eql(5)
                 done()
@@ -1019,7 +1019,7 @@ describe('request', function () {
             doReq()
             let messages = 0
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 messages++
                 const packet = parse(msg)
                 const toSend = generate({
@@ -1031,7 +1031,7 @@ describe('request', function () {
                 server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -1042,7 +1042,7 @@ describe('request', function () {
 
     describe('observe', function () {
         function doObserve () {
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
 
                 if (packet.ack) {
@@ -1101,7 +1101,7 @@ describe('request', function () {
         it('should ack the update', function (done) {
             doObserve()
 
-            server.on('message', function (msg) {
+            server.on('message', (msg) => {
                 if (parse(msg).ack) {
                     done()
                 }
@@ -1111,13 +1111,13 @@ describe('request', function () {
         it('should emit any more data after close', function (done) {
             const req = doObserve()
 
-            req.on('response', function (res) {
-                res.once('data', function (data) {
+            req.on('response', (res) => {
+                res.once('data', (data) => {
                     expect(data.toString()).to.eql('42')
                     res.close()
                     done()
 
-                    res.on('data', function (data) {
+                    res.on('data', (data) => {
                         done(new Error('this should never happen'))
                     })
                 })
@@ -1127,8 +1127,8 @@ describe('request', function () {
         it('should send origin and destination socket data along with the response', function (done) {
             const req = doObserve()
 
-            req.on('response', function (res) {
-                res.once('data', function (data) {
+            req.on('response', (res) => {
+                res.once('data', (data) => {
                     expect(res).to.have.property('rsinfo')
                     expect(res).to.have.property('outSocket')
                     expect(res.outSocket).to.have.property('address')
@@ -1142,13 +1142,13 @@ describe('request', function () {
         it('should emit any more data after close', function (done) {
             const req = doObserve()
 
-            req.on('response', function (res) {
-                res.once('data', function (data) {
+            req.on('response', (res) => {
+                res.once('data', (data) => {
                     expect(data.toString()).to.eql('42')
                     res.close()
                     done()
 
-                    res.on('data', function (data) {
+                    res.on('data', (data) => {
                         done(new Error('this should never happen'))
                     })
                 })
@@ -1158,12 +1158,12 @@ describe('request', function () {
         it('should send deregister request if close(eager=true)', function (done) {
             const req = doObserve()
 
-            req.on('response', function (res) {
-                res.once('data', function (data) {
+            req.on('response', (res) => {
+                res.once('data', (data) => {
                     expect(data.toString()).to.eql('42')
                     res.close(true)
 
-                    server.on('message', function (msg, rsinfo) {
+                    server.on('message', (msg, rsinfo) => {
                         const packet = parse(msg)
                         if (packet.ack && (packet.code === '0.00')) {
                             return
@@ -1188,7 +1188,7 @@ describe('request', function () {
                 observe: true
             }).end()
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 expect(packet.options[0].name).to.eql('Observe')
                 expect(packet.options[0].value).to.eql(Buffer.alloc(0))
@@ -1202,7 +1202,7 @@ describe('request', function () {
                 observe: 1
             }).end()
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 try {
                     expect(packet.options[0].name).to.eql('Observe')
@@ -1216,7 +1216,7 @@ describe('request', function () {
         })
 
         it('should allow multiple notifications', function (done) {
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const req = parse(msg)
 
                 sendNotification(rsinfo, req, { num: 0, payload: 'zero' })
@@ -1229,7 +1229,7 @@ describe('request', function () {
                 confirmable: false
             }).end()
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 let ndata = 0
 
                 res.on('data', function (data) {
@@ -1249,7 +1249,7 @@ describe('request', function () {
         })
 
         it('should drop out of order notifications', function (done) {
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const req = parse(msg)
 
                 sendNotification(rsinfo, req, { num: 1, payload: 'one' })
@@ -1263,10 +1263,10 @@ describe('request', function () {
                 confirmable: false
             }).end()
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 let ndata = 0
 
-                res.on('data', function (data) {
+                res.on('data', (data) => {
                     ndata++
                     if (ndata === 1) {
                         expect(res.headers.Observe).to.equal(1)
@@ -1283,11 +1283,11 @@ describe('request', function () {
         })
 
         it('should allow repeating order after 128 seconds', function (done) {
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const req = parse(msg)
 
                 sendNotification(rsinfo, req, { num: 1, payload: 'one' })
-                setTimeout(function () {
+                setTimeout(() => {
                     sendNotification(rsinfo, req, { num: 1, payload: 'two' })
                 }, 128 * 1000 + 200)
             })
@@ -1298,10 +1298,10 @@ describe('request', function () {
                 confirmable: false
             }).end()
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 let ndata = 0
 
-                res.on('data', function (data) {
+                res.on('data', (data) => {
                     ndata++
                     if (ndata === 1) {
                         expect(res.headers.Observe).to.equal(1)
@@ -1320,7 +1320,7 @@ describe('request', function () {
         })
 
         it('should allow Observe option 24bit overflow', function (done) {
-            server.once('message', function (msg, rsinfo) {
+            server.once('message', (msg, rsinfo) => {
                 const req = parse(msg)
 
                 sendNotification(rsinfo, req, { num: 0xffffff, payload: 'max' })
@@ -1333,10 +1333,10 @@ describe('request', function () {
                 confirmable: false
             }).end()
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 let ndata = 0
 
-                res.on('data', function (data) {
+                res.on('data', (data) => {
                     ndata++
                     if (ndata === 1) {
                         expect(res.headers.Observe).to.equal(0xffffff)
@@ -1376,7 +1376,7 @@ describe('request', function () {
                 port: port
             })
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 const toSend = generate({
                     messageId: packet.messageId,
@@ -1386,9 +1386,9 @@ describe('request', function () {
                 server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
             })
 
-            req.on('error', function () {})
+            req.on('error', () => {})
 
-            req.on('timeout', function () {
+            req.on('timeout', () => {
                 done()
             })
 
@@ -1402,7 +1402,7 @@ describe('request', function () {
                 port: port
             })
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 const toSend = generate({
                     messageId: packet.messageId,
@@ -1412,9 +1412,9 @@ describe('request', function () {
                 server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
             })
 
-            req.on('error', function () {})
+            req.on('error', () => {})
 
-            req.on('timeout', function () {
+            req.on('timeout', () => {
                 done()
             })
 
@@ -1439,7 +1439,7 @@ describe('request', function () {
 
         beforeEach(function (done) {
             sock = dgram.createSocket('udp4')
-            sock.bind(port2, function () {
+            sock.bind(port2, () => {
                 server.addMembership(MULTICAST_ADDR)
                 sock.addMembership(MULTICAST_ADDR)
                 done()
@@ -1453,7 +1453,7 @@ describe('request', function () {
         it('should be non-confirmable', function (done) {
             doReq()
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 expect(packet).to.have.property('confirmable', false)
                 done()
@@ -1464,7 +1464,7 @@ describe('request', function () {
             const req = doReq()
             let token
 
-            server.on('message', function (msg, rsinfo) {
+            server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 token = packet.token
 
@@ -1479,7 +1479,7 @@ describe('request', function () {
                 server.send(toSend, 0, toSend.length, rsinfo.port, rsinfo.address)
             })
 
-            req.on('response', function (res) {
+            req.on('response', (res) => {
                 const packet = res._packet
                 expect(packet).to.have.property('confirmable', false)
                 expect(packet).to.have.property('reset', false)
@@ -1494,8 +1494,8 @@ describe('request', function () {
             const servers = [undefined, undefined]
             const mids = [0, 0]
 
-            servers.forEach(function (_, i) {
-                servers[i] = coap.createServer(function (req, res) {
+            servers.forEach((_, i) => {
+                servers[i] = coap.createServer((req, res) => {
                     const mid = _req._packet.messageId + i + 1
                     res._packet.messageId = mid
                     mids[i] = mid
@@ -1509,9 +1509,9 @@ describe('request', function () {
                 port: port2,
                 confirmable: false,
                 multicast: true
-            }).on('response', function (res) {
+            }).on('response', (res) => {
                 if (++counter === servers.length) {
-                    mids.forEach(function (mid, i) {
+                    mids.forEach((mid, i) => {
                         expect(mid).to.eql(_req._packet.messageId + i + 1)
                     })
                     done()
@@ -1534,7 +1534,7 @@ describe('request', function () {
                 pathname: '/hello',
                 confirmable: false,
                 multicast: true
-            }).on('response', function (res) {
+            }).on('response', (res) => {
                 expect(res.payload.toString()).to.eql(payload.toString())
                 done()
             }).end()
@@ -1555,11 +1555,11 @@ describe('request', function () {
                 multicast: true
             })
 
-            _req.on('bestEventEver', function () {
+            _req.on('bestEventEver', () => {
                 done()
             })
 
-            _req.on('response', function (res) {
+            _req.on('response', (res) => {
                 expect(res.payload.toString()).to.eql(payload.toString())
                 _req.emit('bestEventEver')
             }).end()
@@ -1585,11 +1585,11 @@ describe('request', function () {
                 port: port2,
                 confirmable: false,
                 multicast: true
-            }).on('response', function (res) {
+            }).on('response', (res) => {
                 counter++
             }).end()
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(counter).to.eql(1)
                 done()
             }, 45 * 1000)

--- a/test/server.js
+++ b/test/server.js
@@ -61,7 +61,7 @@ describe('server', function () {
 
     it('should receive a CoAP message', function (done) {
         send(generate())
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             done()
         })
     })
@@ -70,7 +70,7 @@ describe('server', function () {
         port = 5683
         server.close() // refresh
         server = coap.createServer()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             done()
         })
         server.listen()
@@ -81,14 +81,14 @@ describe('server', function () {
         port = 5683
         server.close() // refresh
         server = coap.createServer()
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             done()
         })
 
         const sock = new events.EventEmitter()
-        sock.send = function () { }
+        sock.send = () => { }
 
-        server.listen(sock, function () {
+        server.listen(sock, () => {
             expect(server._sock).to.eql(sock)
             sock.emit('message', generate(), { address: '127.0.0.1', port: nextPort() })
         })
@@ -97,7 +97,7 @@ describe('server', function () {
     it('should use the listener passed as a parameter in the creation', function (done) {
         port = 5683
         server.close() // refresh
-        server = coap.createServer({}, function (req, res) {
+        server = coap.createServer({}, (req, res) => {
             done()
         })
         server.listen()
@@ -108,10 +108,10 @@ describe('server', function () {
         server.close() // we need to change port
         server = coap.createServer()
         port = 5683
-        server.listen(function () {
+        server.listen(() => {
             send(generate())
         })
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             done()
         })
     })
@@ -119,8 +119,8 @@ describe('server', function () {
     it('should receive a request that can be piped', function (done) {
         const buf = Buffer.alloc(25)
         send(generate({ payload: buf }))
-        server.on('request', function (req, res) {
-            req.pipe(bl(function (err, data) {
+        server.on('request', (req, res) => {
+            req.pipe(bl((err, data) => {
                 if (err) {
                     done(err)
                 } else {
@@ -134,7 +134,7 @@ describe('server', function () {
     it('should expose the payload', function (done) {
         const buf = Buffer.alloc(25)
         send(generate({ payload: buf }))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req.payload).to.eql(buf)
             done()
         })
@@ -143,7 +143,7 @@ describe('server', function () {
     it('should include an URL in the request', function (done) {
         const buf = Buffer.alloc(25)
         send(generate({ payload: buf }))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('url', '/')
             done()
         })
@@ -152,7 +152,7 @@ describe('server', function () {
     it('should include the code', function (done) {
         const buf = Buffer.alloc(25)
         send(generate({ payload: buf }))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('code', '0.01')
             done()
         })
@@ -160,7 +160,7 @@ describe('server', function () {
 
     it('should include a rsinfo', function (done) {
         send(generate())
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('rsinfo')
             expect(req.rsinfo).to.have.property('address')
             expect(req.rsinfo).to.have.property('port')
@@ -172,7 +172,7 @@ describe('server', function () {
     ;['GET', 'POST', 'PUT', 'DELETE'].forEach(function (method) {
         it('should include the \'' + method + '\' method', function (done) {
             send(generate({ code: method }))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 expect(req).to.have.property('method', method)
                 done()
             })
@@ -190,7 +190,7 @@ describe('server', function () {
             }]
         }))
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('url', '/hello/world')
             done()
         })
@@ -207,7 +207,7 @@ describe('server', function () {
             }]
         }))
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('url', '/?a=b&b=c')
             done()
         })
@@ -230,7 +230,7 @@ describe('server', function () {
             }]
         }))
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req).to.have.property('url', '/hello/world?a=b&b=c')
             done()
         })
@@ -246,7 +246,7 @@ describe('server', function () {
             options: options
         }))
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             expect(req.options).to.eql(options)
             done()
         })
@@ -256,7 +256,7 @@ describe('server', function () {
         const buf = Buffer.alloc(25)
         const tok = Buffer.alloc(4)
         send(generate({ payload: buf, token: tok }))
-        client.on('message', function (msg, rinfo) {
+        client.on('message', (msg, rinfo) => {
             const result = parse(msg)
             expect(result.code).to.eql('0.00')
             expect(result.reset).to.eql(true)
@@ -265,13 +265,13 @@ describe('server', function () {
             expect(result.payload.length).to.eql(0)
             done()
         })
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.reset()
         })
     })
 
     it('should only close once', function (done) {
-        server.close(function () {
+        server.close(() => {
             server.close(done)
         })
     })
@@ -305,7 +305,7 @@ describe('server', function () {
                     }]
                 }))
 
-                server.on('request', function (req) {
+                server.on('request', (req) => {
                     expect(req.options[0].value).to.eql(format)
                     done()
                 })
@@ -319,7 +319,7 @@ describe('server', function () {
                     }]
                 }))
 
-                server.on('request', function (req) {
+                server.on('request', (req) => {
                     expect(req.headers).to.have.property(option, format)
                     done()
                 })
@@ -341,7 +341,7 @@ describe('server', function () {
                 }]
             }))
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 const response = parse(msg)
 
                 expect(response.code).to.equal('2.05')
@@ -349,7 +349,7 @@ describe('server', function () {
                 done()
             })
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 expect(req.headers['Content-Format']).to.equal(1542)
                 res.end()
             })
@@ -363,7 +363,7 @@ describe('server', function () {
                 }]
             }))
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 const response = parse(msg)
 
                 expect(response.code).to.equal('2.05')
@@ -371,7 +371,7 @@ describe('server', function () {
                 done()
             })
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 expect(req.headers['Content-Format']).to.equal(undefined)
                 res.end()
             })
@@ -387,7 +387,7 @@ describe('server', function () {
 
         function sendAndRespond (status) {
             send(generate(packet))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 if (status) {
                     res.statusCode = status
                 }
@@ -398,7 +398,7 @@ describe('server', function () {
 
         it('should reply with a payload to a NON message', function (done) {
             sendAndRespond()
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).payload).to.eql(Buffer.from('42'))
                 done()
             })
@@ -406,7 +406,7 @@ describe('server', function () {
 
         it('should include the original messageId', function (done) {
             sendAndRespond()
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).messageId).to.eql(4242)
                 done()
             })
@@ -414,7 +414,7 @@ describe('server', function () {
 
         it('should include the token', function (done) {
             sendAndRespond()
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).token).to.eql(packet.token)
                 done()
             })
@@ -422,7 +422,7 @@ describe('server', function () {
 
         it('should respond with a different code', function (done) {
             sendAndRespond('2.04')
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).code).to.eql('2.04')
                 done()
             })
@@ -430,7 +430,7 @@ describe('server', function () {
 
         it('should respond with a numeric code', function (done) {
             sendAndRespond(204)
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).code).to.eql('2.04')
                 done()
             })
@@ -441,12 +441,12 @@ describe('server', function () {
 
             send(generate(packet))
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('ETag', buf)
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).options[0].name).to.eql('ETag')
                 expect(parse(msg).options[0].value).to.eql(buf)
                 done()
@@ -458,13 +458,13 @@ describe('server', function () {
 
             send(generate(packet))
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('ETag', Buffer.alloc(3))
                 res.setOption('ETag', buf)
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).options[0].value).to.eql(buf)
                 done()
             })
@@ -473,12 +473,12 @@ describe('server', function () {
         it('should alias setOption to setHeader', function (done) {
             send(generate(packet))
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setHeader('ETag', 'hello world')
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).options[0].name).to.eql('ETag')
                 expect(parse(msg).options[0].value).to.eql(Buffer.from('hello world'))
                 done()
@@ -491,12 +491,12 @@ describe('server', function () {
 
             send(generate(packet))
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('433', [buf1, buf2])
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).options[0].value).to.eql(buf1)
                 expect(parse(msg).options[1].value).to.eql(buf2)
                 done()
@@ -507,7 +507,7 @@ describe('server', function () {
             send(generate(packet))
             send(generate(packet))
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('42')
 
                 // this will error if called twice
@@ -520,11 +520,11 @@ describe('server', function () {
             let first = true
             const delay = (params.exchangeLifetime * 1000) + 1
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 if (first) {
                     res.end('42')
                     first = false
-                    setTimeout(function () {
+                    setTimeout(() => {
                         send(generate(packet))
                     }, delay)
 
@@ -541,12 +541,12 @@ describe('server', function () {
         it('should include \'ETag\' in the response options', function (done) {
             send(generate())
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('ETag', 'abcdefgh')
                 res.end('42')
             })
 
-            client.on('message', function (msg, rsinfo) {
+            client.on('message', (msg, rsinfo) => {
                 expect(parse(msg).options[0].name).to.eql('ETag')
                 expect(parse(msg).options[0].value).to.eql(Buffer.from('abcdefgh'))
                 done()
@@ -556,12 +556,12 @@ describe('server', function () {
         it('should include \'Content-Format\' in the response options', function (done) {
             send(generate())
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.setOption('Content-Format', 'text/plain')
                 res.end('42')
             })
 
-            client.on('message', function (msg, rsinfo) {
+            client.on('message', (msg, rsinfo) => {
                 expect(parse(msg).options[0].name).to.eql('Content-Format')
                 expect(parse(msg).options[0].value).to.eql(Buffer.of(0))
                 done()
@@ -570,7 +570,7 @@ describe('server', function () {
 
         it('should reply with a \'5.00\' if it cannot parse the packet', function (done) {
             send(Buffer.alloc(3))
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 expect(parse(msg).code).to.eql('5.00')
                 done()
             })
@@ -582,15 +582,15 @@ describe('server', function () {
             let messages = 0
 
             send(generate(packet))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 messages++
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -608,11 +608,11 @@ describe('server', function () {
 
         it('should reply in piggyback', function (done) {
             send(generate(packet))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 const response = parse(msg)
                 expect(response.ack).to.be.true // eslint-disable-line no-unused-expressions
                 expect(response.messageId).to.eql(packet.messageId)
@@ -624,7 +624,7 @@ describe('server', function () {
         it('should ack the message if it does not reply in 50ms', function (done) {
             send(generate(packet))
 
-            client.once('message', function (msg) {
+            client.once('message', (msg) => {
                 const response = parse(msg)
                 expect(response.ack).to.be.true // eslint-disable-line no-unused-expressions
                 expect(response.code).to.eql('0.00')
@@ -640,17 +640,17 @@ describe('server', function () {
             clock = sinon.useFakeTimers(0, 'Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval')
 
             send(generate(packet))
-            server.on('request', function (req, res) {
-                setTimeout(function () {
+            server.on('request', (req, res) => {
+                setTimeout(() => {
                     res.end('42')
                 }, 200)
             })
 
-            client.once('message', function (msg) {
+            client.once('message', (msg) => {
                 const response = parse(msg)
                 expect(response.ack).to.be.true // eslint-disable-line no-unused-expressions
 
-                client.once('message', function (msg) {
+                client.once('message', (msg) => {
                     const response = parse(msg)
 
                     expect(response.confirmable).to.be.true // eslint-disable-line no-unused-expressions
@@ -668,19 +668,19 @@ describe('server', function () {
             let messages = 0
 
             send(generate(packet))
-            server.on('request', function (req, res) {
-                setTimeout(function () {
+            server.on('request', (req, res) => {
+                setTimeout(() => {
                     res.end('42')
                 }, 200)
             })
 
-            client.once('message', function (msg) {
-                client.on('message', function (msg) {
+            client.once('message', (msg) => {
+                client.on('message', (msg) => {
                     messages++
                 })
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 try {
                     // original one plus 4 retries
                     expect(messages).to.eql(5)
@@ -699,14 +699,14 @@ describe('server', function () {
             let messages = 0
 
             send(generate(packet))
-            server.on('request', function (req, res) {
-                setTimeout(function () {
+            server.on('request', (req, res) => {
+                setTimeout(() => {
                     res.end('42')
                 }, 200)
             })
 
-            client.once('message', function (msg) {
-                client.on('message', function (msg) {
+            client.once('message', (msg) => {
+                client.on('message', (msg) => {
                     const res = parse(msg)
                     send(generate({
                         code: '0.00',
@@ -717,7 +717,7 @@ describe('server', function () {
                 })
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -731,15 +731,15 @@ describe('server', function () {
             let messages = 0
 
             send(generate(packet))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.end('42')
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 messages++
             })
 
-            setTimeout(function () {
+            setTimeout(() => {
                 expect(messages).to.eql(1)
                 done()
             }, 45 * 1000)
@@ -751,13 +751,13 @@ describe('server', function () {
             clock = sinon.useFakeTimers(0, 'Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval')
 
             send(generate(packet))
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 // needed to avoid sending a piggyback response
-                setTimeout(function () {
+                setTimeout(() => {
                     res.end('42')
                 }, 200)
 
-                res.on('error', function (err) {
+                res.on('error', (err) => {
                     expect(err).to.have.property('retransmitTimeout', 247)
                     done()
                 })
@@ -806,11 +806,11 @@ describe('server', function () {
         ['PUT', 'POST', 'DELETE'].forEach(function (method) {
             it('should return an error when try to observe in a ' + method, function (done) {
                 doObserve(method)
-                server.on('request', function () {
+                server.on('request', () => {
                     done(new Error('A request should not be emitted'))
                 })
 
-                client.on('message', function (msg) {
+                client.on('message', (msg) => {
                     expect(parse(msg).code).to.eql('5.00')
                     done()
                 })
@@ -819,7 +819,7 @@ describe('server', function () {
 
         it('should include a rsinfo', function (done) {
             doObserve()
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 expect(req).to.have.property('rsinfo')
                 expect(req.rsinfo).to.have.property('address')
                 expect(req.rsinfo).to.have.property('port')
@@ -830,7 +830,7 @@ describe('server', function () {
 
         it('should emit a request with \'Observe\' in the headers', function (done) {
             doObserve()
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 expect(req.headers).to.have.property('Observe')
                 res.end('hello')
                 done()
@@ -840,7 +840,7 @@ describe('server', function () {
         it('should send multiple messages for multiple writes', function (done) {
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.write('hello')
                 originalSetImmediate(function () {
                     res.end('world')
@@ -848,7 +848,7 @@ describe('server', function () {
             })
 
             // the first one is an ack
-            client.once('message', function (msg) {
+            client.once('message', (msg) => {
                 expect(parse(msg).payload.toString()).to.eql('hello')
                 expect(parse(msg).options[0].name).to.eql('Observe')
                 expect(parse(msg).options[0].value).to.eql(Buffer.of(1))
@@ -856,7 +856,7 @@ describe('server', function () {
                 expect(parse(msg).code).to.eql('2.05')
                 expect(parse(msg).ack).to.be.true // eslint-disable-line no-unused-expressions
 
-                client.once('message', function (msg) {
+                client.once('message', (msg) => {
                     expect(parse(msg).payload.toString()).to.eql('world')
                     expect(parse(msg).options[0].name).to.eql('Observe')
                     expect(parse(msg).options[0].value).to.eql(Buffer.of(2))
@@ -875,7 +875,7 @@ describe('server', function () {
 
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 // the first is the current status
                 // it's in piggyback on the ack
                 res.write('hello')
@@ -883,7 +883,7 @@ describe('server', function () {
                 // the second status is on the observe
                 res.write('hello2')
 
-                res.on('finish', function () {
+                res.on('finish', () => {
                     done()
                 })
             })
@@ -894,15 +894,15 @@ describe('server', function () {
         it('should emit a \'finish\' if the client do a reset', function (done) {
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.write('hello')
                 res.write('world')
-                res.on('finish', function () {
+                res.on('finish', () => {
                     done()
                 })
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 const packet = parse(msg)
                 send(generate({
                     reset: true,
@@ -915,11 +915,11 @@ describe('server', function () {
         it('should send a \'RST\' to the client if the msg.reset() method is invoked', function (done) {
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 res.reset()
             })
 
-            client.on('message', function (msg) {
+            client.on('message', (msg) => {
                 const result = parse(msg)
                 expect(result.code).to.eql('0.00')
                 expect(result.reset).to.eql(true)
@@ -933,7 +933,7 @@ describe('server', function () {
         it('should correctly generate two-byte long sequence numbers', function (done) {
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 // hack to override the message counter
                 res._counter = 4242
 
@@ -944,10 +944,10 @@ describe('server', function () {
             })
 
             // the first one is an ack
-            client.once('message', function (msg) {
+            client.once('message', (msg) => {
                 expect(parse(msg).options[0].value).to.eql(Buffer.of(0x10, 0x93))
 
-                client.once('message', function (msg) {
+                client.once('message', (msg) => {
                     expect(parse(msg).options[0].value).to.eql(Buffer.of(0x10, 0x94))
                     done()
                 })
@@ -957,7 +957,7 @@ describe('server', function () {
         it('should correctly generate three-byte long sequence numbers', function (done) {
             doObserve()
 
-            server.on('request', function (req, res) {
+            server.on('request', (req, res) => {
                 // hack to override the message counter
                 res._counter = 65535
 
@@ -968,10 +968,10 @@ describe('server', function () {
             })
 
             // the first one is an ack
-            client.once('message', function (msg) {
+            client.once('message', (msg) => {
                 expect(parse(msg).options[0].value).to.eql(Buffer.of(1, 0, 0))
 
-                client.once('message', function (msg) {
+                client.once('message', (msg) => {
                     expect(parse(msg).options[0].value).to.eql(Buffer.of(1, 0, 1))
                     done()
                 })
@@ -989,7 +989,7 @@ describe('server', function () {
 
             server.listen(port)
 
-            server.on('request', function (msg) {
+            server.on('request', (msg) => {
                 done()
             })
 
@@ -1029,14 +1029,14 @@ describe('validate custom server options', function () {
         let messages = 0
         server = coap.createServer({ piggybackReplyMs: piggyBackTimeout })
         server.listen(port)
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('42')
         })
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             messages++
         })
         send(Buffer.alloc(3))
-        setTimeout(function () {
+        setTimeout(() => {
             expect(messages).to.eql(1)
             expect(server._options.piggybackReplyMs).to.eql(piggyBackTimeout)
             done()
@@ -1100,10 +1100,10 @@ describe('validate custom server options', function () {
     it('should send ACK for non-confirmable message, sendAcksForNonConfirmablePackets=true', function (done) {
         server = coap.createServer({ sendAcksForNonConfirmablePackets: true })
         server.listen(port)
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('42')
         })
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             done()
         })
         sendNonConfirmableMessage()
@@ -1113,14 +1113,14 @@ describe('validate custom server options', function () {
         let messages = 0
         server = coap.createServer({ sendAcksForNonConfirmablePackets: false })
         server.listen(port)
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('42')
         })
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             messages++
         })
         sendNonConfirmableMessage()
-        setTimeout(function () {
+        setTimeout(() => {
             expect(messages).to.eql(0)
             done()
         }, 30)
@@ -1129,10 +1129,10 @@ describe('validate custom server options', function () {
     it('should send ACK for confirmable message, sendAcksForNonConfirmablePackets=true', function (done) {
         server = coap.createServer({ sendAcksForNonConfirmablePackets: true })
         server.listen(port)
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('42')
         })
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             done()
         })
         sendConfirmableMessage()
@@ -1178,7 +1178,7 @@ describe('server LRU', function () {
 
     it('should remove old packets after < exchangeLifetime x 1.5', function (done) {
         send(generate(packet))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end()
 
             expect(server._lru.itemCount, 1)
@@ -1233,7 +1233,7 @@ describe('server block cache', function () {
 
     it('should have block1Cache return {}', function (done) {
         send(generate(packet))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end()
             expect(server._block1Cache._factory()).to.eql({})
             done()
@@ -1242,7 +1242,7 @@ describe('server block cache', function () {
 
     it('should have block2Cache return null', function (done) {
         send(generate(packet))
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end()
             expect(server._block2Cache._factory()).to.eql(null)
             done()
@@ -1257,7 +1257,7 @@ describe('Client Identifier', function () {
         client,
         clock
 
-    const packet = function (key) {
+    const packet = (key) => {
         return {
             confirmable: true,
             messageId: 4242,
@@ -1306,12 +1306,12 @@ describe('Client Identifier', function () {
         let messagesSent = 0
         let messagesReceived = 0
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(`${messagesSent}`)
             messagesSent += 1
         })
 
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             const result = parse(msg)
             expect(result.payload.toString(), '0')
             messagesReceived += 1
@@ -1329,12 +1329,12 @@ describe('Client Identifier', function () {
         let messagesSent = 0
         let messagesReceived = 0
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end(`${messagesSent}`)
             messagesSent += 1
         })
 
-        client.on('message', function (msg) {
+        client.on('message', (msg) => {
             const result = parse(msg)
             expect(result.payload.toString(), `${messagesReceived}`)
             messagesReceived += 1

--- a/test/share-socket.js
+++ b/test/share-socket.js
@@ -19,7 +19,7 @@ describe('share-socket', function () {
     beforeEach(function (done) {
         port = nextPort()
         server = coap.createServer()
-        server.listen(port, function () {
+        server.listen(port, () => {
             coap.globalAgent = new coap.Agent({
                 socket: server._sock
             })
@@ -29,19 +29,19 @@ describe('share-socket', function () {
 
     afterEach(function (done) {
         this.timeout(200)
-        setTimeout(function () {
+        setTimeout(() => {
             server.close(done)
-            server.on('error', function () {})
+            server.on('error', () => {})
         }, 100)
     })
 
-    process.on('uncaughtException', function (err) {
+    process.on('uncaughtException', (err) => {
         console.log('Caught exception: ' + err)
     })
 
     it('should receive a request at a path with some query', function (done) {
         coap.request('coap://localhost:' + port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.url).to.eql('/abcd/ef/gh?foo=bar&beep=bop')
             setImmediate(done)
         })
@@ -49,12 +49,12 @@ describe('share-socket', function () {
 
     it('should return code 2.05 by default', function (done) {
         const req = coap.request('coap://localhost:' + port + '/abcd/ef/gh/?foo=bar&beep=bop').end()
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('2.05')
             setImmediate(done)
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
         })
     })
@@ -62,13 +62,13 @@ describe('share-socket', function () {
     it('should return code using res.code attribute', function (done) {
         coap
             .request('coap://localhost:' + port)
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.04')
                 setImmediate(done)
             })
             .end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.code = '4.04'
             res.end('hello')
         })
@@ -77,13 +77,13 @@ describe('share-socket', function () {
     it('should return code using res.statusCode attribute', function (done) {
         coap
             .request('coap://localhost:' + port)
-            .on('response', function (res) {
+            .on('response', (res) => {
                 expect(res.code).to.eql('4.04')
                 setImmediate(done)
             })
             .end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end('hello')
         })
@@ -95,17 +95,17 @@ describe('share-socket', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
-            res.once('data', function (data) {
+        req.on('response', (res) => {
+            res.once('data', (data) => {
                 expect(data.toString()).to.eql('hello')
-                res.once('data', function (data) {
+                res.once('data', (data) => {
                     expect(data.toString()).to.eql('world')
                     done()
                 })
             })
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.write('hello')
             res.end('world')
         })
@@ -117,12 +117,12 @@ describe('share-socket', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('4.04')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end()
         })
@@ -134,13 +134,13 @@ describe('share-socket', function () {
             observe: true
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.code).to.eql('4.04')
             res.on('end', done)
             res.resume()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.statusCode = '4.04'
             res.end()
         })
@@ -158,7 +158,7 @@ describe('share-socket', function () {
                     req.setOption(option, format)
                     req.end()
 
-                    server.on('request', function (req) {
+                    server.on('request', (req) => {
                         expect(req.options[0].name).to.eql(option)
                         expect(req.options[0].value).to.eql(format)
                         done()
@@ -175,7 +175,7 @@ describe('share-socket', function () {
 
                     coap.request(req).end()
 
-                    server.on('request', function (req) {
+                    server.on('request', (req) => {
                         expect(req.options[0].name).to.eql(option)
                         expect(req.options[0].value).to.eql(format)
                         done()
@@ -192,7 +192,7 @@ describe('share-socket', function () {
 
                     coap.request(req).end()
 
-                    server.on('request', function (req) {
+                    server.on('request', (req) => {
                         expect(req.headers[option]).to.eql(format)
                         done()
                     })
@@ -203,7 +203,7 @@ describe('share-socket', function () {
                     req.setOption(option, format)
                     req.end()
 
-                    server.on('request', function (req) {
+                    server.on('request', (req) => {
                         expect(req.headers[option]).to.eql(format)
                         done()
                     })
@@ -216,12 +216,12 @@ describe('share-socket', function () {
                 const req = coap.request('coap://localhost:' + port)
                 req.end()
 
-                server.on('request', function (req, res) {
+                server.on('request', (req, res) => {
                     res.setOption('Content-Format', format)
                     res.end()
                 })
 
-                req.on('response', function (res) {
+                req.on('response', (res) => {
                     expect(res.headers['Content-Format']).to.eql(format)
                     done()
                 })
@@ -235,7 +235,7 @@ describe('share-socket', function () {
         req.setOption('Content-Format', 'application/json; charset=utf8')
         req.end()
 
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.options[0].name).to.equal('Content-Format')
             expect(req.options[0].value).to.equal('application/json')
             done()
@@ -248,7 +248,7 @@ describe('share-socket', function () {
         req.setOption('Max-Age', 26763)
         req.end()
 
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.options[0].name).to.equal('Max-Age')
             expect(req.options[0].value).to.equal(26763)
             done()
@@ -258,12 +258,12 @@ describe('share-socket', function () {
     it('should provide a writeHead() method', function (done) {
         const req = coap.request('coap://localhost:' + port)
         req.end()
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers['Content-Format']).to.equal('application/json')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.writeHead(200, { 'Content-Format': 'application/json' })
             res.write(JSON.stringify({}))
             res.end()
@@ -276,12 +276,12 @@ describe('share-socket', function () {
             method: 'PUT'
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers).to.have.property('Location-Path', '/hello')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.setOption('Location-Path', '/hello')
             res.end('hello')
         })
@@ -293,12 +293,12 @@ describe('share-socket', function () {
             method: 'PUT'
         }).end()
 
-        req.on('response', function (res) {
+        req.on('response', (res) => {
             expect(res.headers).to.have.property('Location-Query', 'a=b')
             done()
         })
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.setOption('Location-Query', 'a=b')
             res.end('hello')
         })
@@ -319,17 +319,17 @@ describe('share-socket', function () {
         }).end()
         let completed = 2
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.write('hello')
-            setTimeout(function () {
+            setTimeout(() => {
                 res.end('world')
             }, 10)
         })
 
-        ;[req1, req2].forEach(function (req) {
+        ;[req1, req2].forEach((req) => {
             let local = 2
-            req.on('response', function (res) {
-                res.on('data', function (data) {
+            req.on('response', (res) => {
+                res.on('data', (data) => {
                     if (--local === 0) {
                         --completed
                     }
@@ -355,7 +355,7 @@ describe('share-socket', function () {
         }).end()
         let first
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             if (!first) {
                 first = req.rsinfo
@@ -376,7 +376,7 @@ describe('share-socket', function () {
         }).end()
         let first
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             if (!first) {
                 first = req.rsinfo
@@ -386,8 +386,8 @@ describe('share-socket', function () {
             }
         })
 
-        req1.on('response', function () {
-            setImmediate(function () {
+        req1.on('response', () => {
+            setImmediate(() => {
                 coap.request({
                     port: port,
                     method: 'GET',
@@ -406,7 +406,7 @@ describe('share-socket', function () {
             agent: agent
         }).end()
 
-        server.on('request', function (req, res) {
+        server.on('request', (req, res) => {
             res.end('hello')
             expect(req.rsinfo.port).eql(3636)
             done()
@@ -418,7 +418,7 @@ describe('share-socket', function () {
         req.setOption('Cache-Control', 'private')
         req.end()
 
-        server.on('request', function (req) {
+        server.on('request', (req) => {
             expect(req.headers).not.to.have.property('Cache-Control')
             done()
         })
@@ -436,7 +436,7 @@ describe('share-socket', function () {
             }
         }
 
-        req.on('error', function (err) {
+        req.on('error', (err) => {
             expect(err).to.have.property('message', 'No reply in 247s')
             clock.restore()
             done()


### PR DESCRIPTION
This PR should make the codebase a bit more concise by getting rid of most of the `function` statements which are no longer necessary due to the addition of error functions.

An exception to this are the `function` statements used in the `mocha` tests as passing arrow functions to `mocha` is [discouraged](https://mochajs.org/#arrow-functions). 