### PR TITLE
feat: refactor and add type declarations for `ObserveReadStream`, add copyright headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ import Agent from './lib/agent'
 import Server from './lib/server'
 import IncomingMessage from './lib/incoming_message'
 import OutgoingMessage from './lib/outgoing_message'
+import ObserveReadStream from './lib/observe_read_stream'
 import { CoapMethod, OptionName } from 'coap-packet'
 import { Socket } from 'dgram'
 
@@ -64,7 +65,7 @@ export const parameters: Parameters
 export const globalAgent: Agent
 export const globalAgentIPv6: Agent
 
-export { IncomingMessage, OutgoingMessage, Agent, Server }
+export { IncomingMessage, OutgoingMessage, ObserveReadStream, Agent, Server }
 
 export function requestListener(req: IncomingMessage, res: OutgoingMessage): void
 export function updateTiming(values: Parameters): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import Agent from './lib/agent'
 import Server from './lib/server'
 import IncomingMessage from './lib/incoming_message'

--- a/lib/agent.d.ts
+++ b/lib/agent.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import { EventEmitter } from 'events'
 import { CoapRequestParams, AgentOptions } from '../index'
 import OutgoingMessage from './outgoing_message'

--- a/lib/incoming_message.d.ts
+++ b/lib/incoming_message.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import { Readable } from 'stream'
 import { ParsedPacket, OptionName } from 'coap-packet'
 import { AddressInfo } from 'net'

--- a/lib/incoming_message.d.ts
+++ b/lib/incoming_message.d.ts
@@ -1,13 +1,12 @@
 import { Readable } from 'stream'
-import { ParsedPacket, CoapMethod, OptionName } from 'coap-packet'
+import { ParsedPacket, OptionName } from 'coap-packet'
 import { AddressInfo } from 'net'
 import { Socket } from 'dgram'
-import { Option, OptionValue } from '..'
-
-
+import { Option } from '..'
 
 export default class IncomingMessage extends Readable {
     _packet: ParsedPacket
+    _payloadIndex: number
     url: string
     payload: Buffer
     options: Array<Option>

--- a/lib/incoming_message.js
+++ b/lib/incoming_message.js
@@ -12,8 +12,8 @@ const Readable = require('readable-stream').Readable
 const pktToMsg = require('./helpers').packetToMessage
 
 class IncomingMessage extends Readable {
-    constructor (packet, rsinfo, outSocket) {
-        super()
+    constructor (packet, rsinfo, outSocket, options) {
+        super(options)
 
         pktToMsg(this, packet)
 

--- a/lib/observe_read_stream.d.ts
+++ b/lib/observe_read_stream.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import { ParsedPacket } from 'coap-packet'
 import IncomingMessage from './incoming_message'
 

--- a/lib/observe_read_stream.d.ts
+++ b/lib/observe_read_stream.d.ts
@@ -1,0 +1,11 @@
+import { ParsedPacket } from 'coap-packet'
+import IncomingMessage from './incoming_message'
+
+export default class ObserveReadStream extends IncomingMessage {
+    _lastId?: number
+    _lastTime: Date
+    _disableFiltering: boolean
+    close (eagerDeregister?: boolean): void
+    append(packet: ParsedPacket, firstPacket: boolean): void
+    _read (): void
+}

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -8,28 +8,27 @@
  * See the included LICENSE file for more details.
  */
 
-const Readable = require('readable-stream').Readable
+const IncomingMessage = require('./incoming_message')
 const pktToMsg = require('./helpers').packetToMessage
 
-class ObserveReadStream extends Readable {
+class ObserveReadStream extends IncomingMessage {
     constructor (packet, rsinfo, outSocket) {
-        super({ objectMode: true })
-
-        this.rsinfo = rsinfo
-        this.outSocket = outSocket
+        super(packet, rsinfo, outSocket, { objectMode: true })
 
         this._lastId = undefined
         this._lastTime = 0
         this._disableFiltering = false
-        this.append(packet)
+        this.append(packet, true)
     }
 
-    append (packet) {
+    append (packet, firstPacket) {
         if (!this.readable) {
             return
         }
 
-        pktToMsg(this, packet)
+        if (!firstPacket) {
+            pktToMsg(this, packet)
+        }
 
         // First notification
         if (this._lastId === undefined) {

--- a/lib/server.d.ts
+++ b/lib/server.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import { EventEmitter } from 'events'
 import { CoapServerOptions } from '..'
 import { AddressInfo } from 'net'

--- a/ts/test.ts
+++ b/ts/test.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import {
     request,
     createServer,


### PR DESCRIPTION
This PR adds a couple of improvements to the type declarations (especially with regard to `ObserveReadStream`), including copyright headers. The implementation of `ObserveReadStream` also refactored by letting it inherit from `IncomingMessage`.