### PR TITLE
docs: add missing copyright header to `outgoing_message.d.ts`

### DIFF
--- a/lib/outgoing_message.d.ts
+++ b/lib/outgoing_message.d.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2021 node-coap contributors.
+ *
+ * node-coap is licensed under an MIT +no-false-attribs license.
+ * All rights not explicitly granted in the MIT license are reserved.
+ * See the included LICENSE file for more details.
+ */
+
 import { OptionName, ParsedPacket } from 'coap-packet'
 import { Writable } from 'stream'
 import { OptionValue, setOption } from '..'


### PR DESCRIPTION
This PR adds a missing copyright header to a declaration file.