### PR TITLE
chore: ignore auxiliary files when publishing npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
 *~
+*.swp
+.vscode
+*code-workspace
+.idea
+.nyc_output
+coverage
+*.tgz


### PR DESCRIPTION
I noticed that there a couple of configuration files as well as the coverage output included in published packages. This PR adjusts the `.npmignore` file accordingly as it overwrites `.gitignore` files when it exists.