### PR TITLE
refactor(agent): remove obsolete token statements

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -362,7 +362,6 @@ class Agent extends events.EventEmitter {
                 packet.confirmable = false
             }
 
-            let token
             if (!(packet.ack || packet.reset)) {
                 packet.messageId = this._nextMessageId()
                 if ((url.token instanceof Buffer) && (url.token.length > 0)) {
@@ -373,17 +372,16 @@ class Agent extends events.EventEmitter {
                 } else {
                     packet.token = this._nextToken()
                 }
-                token = packet.token.toString('hex')
-                this._tkToMulticastResAddr[token] = []
+                const token = packet.token.toString('hex')
                 if (req.multicast) {
                     this._tkToMulticastResAddr[token] = []
+                }
+                if (token) {
+                    this._tkToReq[token] = req
                 }
             }
 
             this._msgIdToReq[packet.messageId] = req
-            if (token) {
-                this._tkToReq[token] = req
-            }
 
             const block1Buff = getOption(packet.options, 'Block1')
             if (block1Buff) {


### PR DESCRIPTION
This PR does some small refactoring and removes a couple of unneeded statements from the agent.