### PR TITLE
fix(examples): fix problem caused by `new URL`

### DIFF
--- a/examples/blockwise.js
+++ b/examples/blockwise.js
@@ -1,9 +1,15 @@
 const coap = require('../') // or coap
 
 coap.createServer((req, res) => {
-    const path = new URL(req.url)
-    const time = parseInt(path.search.split('=')[1])
-    const pathname = path.pathname.split('/')[1]
+    // FIXME: This has became a bit ugly due to the
+    //        replacement of the depracated url.parse
+    //        with the URL constructor.
+    //        This part of the exmample should be replaced
+    //        once a nicer solution has been found.
+
+    const splitURL = req.url.split('?')
+    const time = parseInt(splitURL[1].split('=')[1])
+    const pathname = splitURL[0].split('/')[1]
 
     res.end(new Array(time + 1).join(pathname + ' '))
 }).listen(() => {


### PR DESCRIPTION
I noticed that there is currently a problem in one of the examples that is caused by the replacement of `url.parse` with the native URL constructor. This PR provides a quick and dirty fix that should be revisited in the future.