### PR TITLE
refactor: unify block1 and block2 terminology

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -243,7 +243,7 @@ class Agent extends events.EventEmitter {
             // accumulate payload
             req._totalPayload = Buffer.concat([req._totalPayload, packet.payload])
 
-            if (block2.moreBlock2) {
+            if (block2.more === 1) {
                 // increase message id for next request
                 this._msgIdToReq.delete(req._packet.messageId)
                 req._packet.messageId = this._nextMessageId()
@@ -251,7 +251,7 @@ class Agent extends events.EventEmitter {
 
                 // next block2 request
                 const block2Val = createBlock2({
-                    moreBlock2: false,
+                    more: 0,
                     num: block2.num + 1,
                     size: block2.size
                 })

--- a/lib/block.js
+++ b/lib/block.js
@@ -7,35 +7,39 @@
  */
 
 const TwoPowTwenty = 1048575
+
 /**
  *
- * @param {Number} sequenceNumber The block sequence number.
- * @param {Boolean} moreBlocks If there are more blocks to follow
- * @param {Number} blockSize
+ * @param numOrBlockState The block sequence number or a block state object.
+ * @param more Can indicate if more blocks are to follow.
+ * @param size The block size.
  */
-module.exports.generateBlockOption = (sequenceNumber, moreBlocks, blockSize) => {
-    if (typeof sequenceNumber === 'object') {
-        moreBlocks = sequenceNumber.moreBlocks
-        blockSize = sequenceNumber.blockSize
-        sequenceNumber = sequenceNumber.sequenceNumber
+module.exports.generateBlockOption = (numOrBlockState, more, size) => {
+    let num
+    if (typeof numOrBlockState === 'object') {
+        num = numOrBlockState.num
+        more = numOrBlockState.more
+        size = numOrBlockState.size
+    } else {
+        num = numOrBlockState
     }
 
-    if (sequenceNumber == null || blockSize == null || sequenceNumber == null) {
+    if (num == null || more == null || size == null) {
         throw new Error('Invalid parameters')
     }
 
-    if (sequenceNumber > TwoPowTwenty) {
+    if (num > TwoPowTwenty) {
         throw new Error('Sequence number out of range')
     }
 
     let buff = Buffer.alloc(4)
 
-    const value = (sequenceNumber << 4) | ((moreBlocks ? (1) : (0)) << 3) | (blockSize & 7)
+    const value = (num << 4) | (more << 3) | (size & 7)
     buff.writeInt32BE(value)
 
-    if (sequenceNumber >= 4096) {
+    if (num >= 4096) {
         buff = buff.slice(1, 4)
-    } else if (sequenceNumber >= 16) {
+    } else if (num >= 16) {
         buff = buff.slice(2, 4)
     } else {
         buff = buff.slice(3, 4)
@@ -57,14 +61,14 @@ module.exports.parseBlockOption = (buff) => {
 
     const value = buff.readInt32BE()
 
-    const sequenceNumber = (value >> 4) & TwoPowTwenty
-    const moreBlocks = ((value & 8) === 8) ? 1 : 0
-    const blockSize = value & 7
+    const num = (value >> 4) & TwoPowTwenty
+    const more = (value & 8) === 8 ? 1 : 0
+    const size = value & 7
 
     return {
-        sequenceNumber: sequenceNumber,
-        moreBlocks: moreBlocks,
-        blockSize: blockSize
+        num,
+        more,
+        size
     }
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -200,6 +200,8 @@ module.exports.simplifyPacketForPrint = (packetIn) => {
 module.exports.parseBlock2 = (block2Value) => {
     let num
     switch (block2Value.length) {
+    case 0:
+        return { more: 0, size: 0, num: 0 }
     case 1:
         num = block2Value[0] >> 4
         break

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,19 +210,20 @@ module.exports.parseBlock2 = (block2Value) => {
         num = (block2Value[0] * 256 * 256 + block2Value[1] * 256 + block2Value[2]) >> 4
         break
     default:
-    // Block2 is more than 3 bytes
+        // Block2 is more than 3 bytes
         return null
     }
+    const lastByte = block2Value.slice(-1)[0]
     // limit value of size is 1024 (2**(6+4))
-    if (block2Value.slice(-1)[0] === 7) {
-    // Block size is bigger than 1024
+    if ((lastByte & 7) === 7) {
+        // Block size is bigger than 1024
         return null
     }
-    const moreValue = block2Value.slice(-1)[0] & (0x01 << 3)
+    const more = (lastByte & 8) >> 3
     return {
-        more: moreValue === 8 ? 1 : 0,
-        num: num,
-        size: Math.pow(2, (block2Value.slice(-1)[0] & 0x07) + 4)
+        more,
+        num,
+        size: Math.pow(2, (lastByte & 7) + 4)
     }
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -189,13 +189,14 @@ module.exports.simplifyPacketForPrint = (packetIn) => {
     packet.options = newOptions
     return packet
 }
-/*
-parse block2
-  value       block2 value buffer
-  return      object describes block2, {moreBlock2: , num: , size: }
 
-with invalid block2 value, the function return null
-*/
+/**
+ * Parse an encoded block2 option and return a block state object.
+ *
+ * @param {Buffer} block2Value block2 value buffer
+ * @returns {Object} Block state object with `num`, `size`, and `more` flag.
+ *                   With an invalid block2 value, the function will return `null`.
+ */
 module.exports.parseBlock2 = (block2Value) => {
     let num
     switch (block2Value.length) {
@@ -217,22 +218,24 @@ module.exports.parseBlock2 = (block2Value) => {
     // Block size is bigger than 1024
         return null
     }
+    const moreValue = block2Value.slice(-1)[0] & (0x01 << 3)
     return {
-        moreBlock2: !!((block2Value.slice(-1)[0] & (0x01 << 3))),
+        more: moreValue === 8 ? 1 : 0,
         num: num,
         size: Math.pow(2, (block2Value.slice(-1)[0] & 0x07) + 4)
     }
 }
 
-/*
-create buffer for block2 option
-  requestedBlock      object contain block2 infor, e.g. {moreBlock2: true, num: 100, size: 32}
-  return              Buffer carrying block2 value
-*/
+/**
+ * Create buffer for block2 option
+ *
+ * @param requestedBlock Object containing block2 information
+ * @returns Buffer carrying block2 value
+ */
 module.exports.createBlock2 = (requestedBlock) => {
     let byte
     const szx = Math.log(requestedBlock.size) / Math.log(2) - 4
-    const m = ((requestedBlock.moreBlock2 === true) ? 1 : 0)
+    const m = requestedBlock.more
     const num = requestedBlock.num
     let extraNum
 

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -19,9 +19,9 @@ class SegmentedTransmission {
         }
 
         this.blockState = {
-            sequenceNumber: 0,
-            moreBlocks: false,
-            blockSize: 0
+            num: 0,
+            more: 0,
+            size: 0
         }
 
         this.setBlockSizeExp(blockSize)
@@ -39,19 +39,19 @@ class SegmentedTransmission {
     }
 
     setBlockSizeExp (blockSizeExp) {
-        this.blockState.blockSize = blockSizeExp
+        this.blockState.size = blockSizeExp
         this.byteSize = exponentToByteSize(blockSizeExp)
     }
 
     updateBlockState () {
-        this.blockState.sequenceNumber = this.currentByte / this.byteSize
-        this.blockState.moreBlocks = ((this.currentByte + this.byteSize) < this.totalLength) ? 1 : 0
+        this.blockState.num = this.currentByte / this.byteSize
+        this.blockState.more = ((this.currentByte + this.byteSize) < this.totalLength) ? 1 : 0
 
         this.req.setOption('Block1', generateBlockOption(this.blockState))
     }
 
     isCorrectACK (packet, retBlockState) {
-        return retBlockState.sequenceNumber === this.blockState.sequenceNumber// && packet.code == "2.31"
+        return retBlockState.num === this.blockState.num// && packet.code == "2.31"
     }
 
     resendPreviousPacket () {
@@ -73,8 +73,8 @@ class SegmentedTransmission {
      * @returns {Boolean} Returns true if the ACK was for the correct block.
      */
     receiveACK (packet, retBlockState) {
-        if (this.blockState.blockSize !== retBlockState.blockSize) {
-            this.setBlockSizeExp(retBlockState.blockSize)
+        if (this.blockState.size !== retBlockState.size) {
+            this.setBlockSizeExp(retBlockState.size)
         }
 
         if (this.remaining() > 0) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -471,13 +471,12 @@ class CoAPServer extends events.EventEmitter {
                     /** @type {{[k:string]:Buffer}} */
                     const cachedData =
                         this._block1Cache.getWithDefaultInsert(cacheKey)
-                    const blockByteSize = Math.pow(2, 4 + blockState.blockSize)
-                    const incomingByteIndex =
-                        blockState.sequenceNumber * blockByteSize
+                    const blockByteSize = Math.pow(2, 4 + blockState.size)
+                    const incomingByteIndex = blockState.num * blockByteSize
                     // Store in the cache object, use the byte index as the key
                     cachedData[incomingByteIndex] = request.payload
 
-                    if (!blockState.moreBlocks) {
+                    if (blockState.more === 0) {
                         // Last block
                         const byteOffsets = Object.keys(cachedData)
                             .map((str) => {
@@ -609,10 +608,10 @@ class OutMessage extends OutgoingMessage {
             return super.end()
         }
         // check if requested block is the last
-        const moreFlag = requestedBlockOption.num < lastBlockNum
+        const more = requestedBlockOption.num < lastBlockNum ? 1 : 0
 
         const block2 = createBlock2({
-            moreBlock2: moreFlag,
+            more,
             num: requestedBlockOption.num,
             size: requestedBlockOption.size
         })

--- a/test/blockwise.js
+++ b/test/blockwise.js
@@ -334,11 +334,11 @@ describe('blockwise2', function () {
             const block2 = parseBlock2(block2Buff)
             expect(block2).to.not.eql(null)
 
-            const expectMore = (req1Block2Num + 1) * 16 <= payloadLength
+            const expectMore = (req1Block2Num + 1) * 16 <= payloadLength ? 1 : 0
 
-            // Have correct num / moreBlock2 fields?
+            // Have correct num / more fields?
             expect(block2.num).to.eql(req1Block2Num)
-            expect(block2.moreBlock2).to.eql(expectMore)
+            expect(block2.more).to.eql(expectMore)
         }
 
         parallelBlock2Test(done, checkNothing, checkBlock2Option, checkNothing)
@@ -403,9 +403,9 @@ describe('blockwise1', () => {
         it('it should return object', (done) => {
             const payload = Buffer.of(0x01)
             const response = {
-                sequenceNumber: 0,
-                moreBlocks: 0,
-                blockSize: 1
+                num: 0,
+                more: 0,
+                size: 1
             }
             const value = block.parseBlockOption(payload)
             expect(value).to.eql(response)
@@ -415,9 +415,9 @@ describe('blockwise1', () => {
         it('it should return object when length is equal to 2', (done) => {
             const payload = Buffer.of(0x01, 0x02)
             const response = {
-                sequenceNumber: 16,
-                moreBlocks: 0,
-                blockSize: 2
+                num: 16,
+                more: 0,
+                size: 2
             }
             const value = block.parseBlockOption(payload)
             expect(value).to.eql(response)
@@ -427,9 +427,9 @@ describe('blockwise1', () => {
         it('it should return object when length is equal to 3', (done) => {
             const payload = Buffer.of(0x01, 0x02, 0x03)
             const response = {
-                sequenceNumber: 4128,
-                moreBlocks: 0,
-                blockSize: 3
+                num: 4128,
+                more: 0,
+                size: 3
             }
             const value = block.parseBlockOption(payload)
             expect(value).to.eql(response)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -123,14 +123,14 @@ describe('Helpers', () => {
     describe('Create Block2', () => {
         it('Should return a buffer carrying a block 2 value', (done) => {
             const buff = Buffer.from([0xff, 0xff, 0xe9])
-            const block = { moreBlock2: true, num: 1048574, size: 32 }
+            const block = { more: 1, num: 1048574, size: 32 }
             const res = createBlock2(block)
             expect(res).to.eql(buff)
             setImmediate(done)
         })
 
         it('Should return null', (done) => {
-            const block = { moreBlock2: true, num: 1048576, size: 32 }
+            const block = { more: 1, num: 1048576, size: 32 }
             const res = createBlock2(block)
             expect(res).to.eql(null)
             setImmediate(done)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -118,6 +118,13 @@ describe('Helpers', () => {
             expect(res).to.eql(null)
             setImmediate(done)
         })
+
+        it('Should parse a zero length buffer', (done) => {
+            const buff = Buffer.alloc(0)
+            const res = parseBlock2(buff)
+            expect(res).to.eql({ more: 0, num: 0, size: 0 })
+            setImmediate(done)
+        })
     })
 
     describe('Create Block2', () => {

--- a/test/segmentation.js
+++ b/test/segmentation.js
@@ -25,7 +25,7 @@ describe('Segmentation', () => {
         it('should set bytesize to value', (done) => {
             const v = new segment.SegmentedTransmission(1, 1, { payload: [1] })
             v.setBlockSizeExp(6)
-            expect(v.blockState.blockSize).to.eql(6)
+            expect(v.blockState.size).to.eql(6)
             expect(v.byteSize).to.eql(1024)
             setImmediate(done)
         })
@@ -36,13 +36,13 @@ describe('Segmentation', () => {
     describe('Is Correct Acknowledgement', () => {
         it('Should return true', (done) => {
             const v = new segment.SegmentedTransmission(1, 1, { payload: [1] })
-            const value = v.isCorrectACK(1, { sequenceNumber: 0 })
+            const value = v.isCorrectACK(1, { num: 0 })
             expect(value).to.eql(true)
             setImmediate(done)
         })
         it('Should return false', (done) => {
             const v = new segment.SegmentedTransmission(1, 1, { payload: [1] })
-            const value = v.isCorrectACK(1, { sequenceNumber: 1 })
+            const value = v.isCorrectACK(1, { num: 1 })
             expect(value).to.eql(false)
             setImmediate(done)
         })
@@ -82,7 +82,7 @@ describe('Segmentation', () => {
 
             }
             const v = new segment.SegmentedTransmission(1, req, { payload: [1] })
-            v.receiveACK(1, { blockSize: 1 })
+            v.receiveACK(1, { size: 1 })
             v.totalLength = 0
             v.currentByte = 0
             expect(v.resendCount).to.eql(0)


### PR DESCRIPTION
So far both the data structures as well as the terminology in block1 and block2 block state options differed. In preparation for more consistent typing this PR applies some more cleanup to the project.