### PR TITLE
refactor: remove `simplifyPacketForPrint` function

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -176,20 +176,6 @@ module.exports.removeOption = (options, name) => {
     return false
 }
 
-module.exports.simplifyPacketForPrint = (packetIn) => {
-    const packet = Object.assign({}, packetIn)
-    packet.token = packet.token.toString('hex')
-    packet.payload = `Buff: ${packet.payload.length}`
-    const newOptions = {}
-    for (const j in packet.options) {
-        const name = packet.options[j].name
-        const hex = packet.options[j].value.toString('hex')
-        newOptions[name] = hex
-    }
-    packet.options = newOptions
-    return packet
-}
-
 /**
  * Parse an encoded block2 option and return a block state object.
  *

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,7 +10,6 @@ const toCode = require('../lib/helpers').toCode
 const getOption = require('../lib/helpers').getOption
 const hasOption = require('../lib/helpers').hasOption
 const removeOption = require('../lib/helpers').removeOption
-const simplifyPacketForPrint = require('../lib/helpers').simplifyPacketForPrint
 const parseBlock2 = require('../lib/helpers').parseBlock2
 const createBlock2 = require('../lib/helpers').createBlock2
 const { expect } = require('chai')
@@ -69,38 +68,6 @@ describe('Helpers', () => {
                 { name: 'test2', value: 'world' }
             ]
             expect(removeOption(options, 'test')).to.eql(false)
-            setImmediate(done)
-        })
-    })
-
-    describe('Simplify Packet for Print', () => {
-        it('Should return pretty packet', (done) => {
-            const packet = {
-                token: Buffer.from([0x01]),
-                options: [],
-                payload: Buffer.from('01 02 03')
-            }
-            const response = {
-                options: {},
-                payload: 'Buff: 8',
-                token: '01'
-            }
-            expect(simplifyPacketForPrint(packet)).to.eql(response)
-            setImmediate(done)
-        })
-
-        it('Should return packet with options as parsed hex values', (done) => {
-            const packet = {
-                token: Buffer.of(0x01),
-                options: [{ name: 'test', value: Buffer.from([0x01, 0x02]) }],
-                payload: Buffer.from('01 02 03')
-            }
-            const response = {
-                options: { test: '0102' },
-                payload: 'Buff: 8',
-                token: '01'
-            }
-            expect(simplifyPacketForPrint(packet)).to.eql(response)
             setImmediate(done)
         })
     })


### PR DESCRIPTION
This PR removes the `simplifyPacketForPrint` function from the helpers file. I noticed that this function isn't actually being used and as it causes some trouble when introducing type checking I wanted to propose removing it. I think it was introduced by @Jamezo97 and @invaderb, would this be okay for you? :)