### PR TITLE
refactor: apply last refactorings before 0.26.0

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -9,24 +9,22 @@
  */
 
 const crypto = require('crypto')
-const events = require('events')
-const dgram = require('dgram')
-const parse = require('coap-packet').parse
-const generate = require('coap-packet').generate
+const { createSocket } = require('dgram')
+const { EventEmitter } = require('events')
+const { parse, generate } = require('coap-packet')
 const IncomingMessage = require('./incoming_message')
 const OutgoingMessage = require('./outgoing_message')
 const ObserveStream = require('./observe_read_stream')
 const RetrySend = require('./retry_send')
-const parseBlock2 = require('./helpers').parseBlock2
-const createBlock2 = require('./helpers').createBlock2
-const getOption = require('./helpers').getOption
-const removeOption = require('./helpers').removeOption
+const { parseBlock2, createBlock2, getOption, removeOption } = require('./helpers')
+const { SegmentedTransmission } = require('./segmentation')
+const { parseBlockOption } = require('./block')
+const { parameters } = require('./parameters')
+
 const maxToken = Math.pow(2, 32)
 const maxMessageId = Math.pow(2, 16)
-const SegmentedTransmission = require('./segmentation').SegmentedTransmission
-const parseBlockOption = require('./block').parseBlockOption
 
-class Agent extends events.EventEmitter {
+class Agent extends EventEmitter {
     constructor (opts) {
         super()
 
@@ -56,10 +54,8 @@ class Agent extends events.EventEmitter {
             return
         }
 
-        const sock = socket || dgram.createSocket({ type: this._opts.type || 'udp4' })
-        this._sock = sock
-
-        sock.on('message', (msg, rsinfo) => {
+        this._sock = socket || createSocket({ type: this._opts.type || 'udp4' })
+        this._sock.on('message', (msg, rsinfo) => {
             let packet
             try {
                 packet = parse(msg)
@@ -74,7 +70,7 @@ class Agent extends events.EventEmitter {
 
             if (this._sock != null) {
                 const outSocket = this._sock.address()
-                this._handle(msg, rsinfo, outSocket)
+                this._handle(packet, rsinfo, outSocket)
             }
         })
 
@@ -128,8 +124,7 @@ class Agent extends events.EventEmitter {
         this._sock = null
     }
 
-    _handle (msg, rsinfo, outSocket) {
-        const packet = parse(msg)
+    _handle (packet, rsinfo, outSocket) {
         let buf
         let response
         let req = this._msgIdToReq.get(packet.messageId)
@@ -148,7 +143,7 @@ class Agent extends events.EventEmitter {
                 req = this._tkToReq.get(packet.token.toString('hex'))
             }
 
-            if ((packet.ack || packet.reset) && !req) {
+            if ((packet.ack || packet.reset) && req == null) {
                 // Nothing to do on unknown or duplicate ACK/RST packet
                 return
             }
@@ -160,8 +155,10 @@ class Agent extends events.EventEmitter {
                     messageId: packet.messageId
                 })
 
-                this._msgInFlight++
-                this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
+                if (this._sock != null) {
+                    this._msgInFlight++
+                    this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
+                }
                 return
             }
         }
@@ -173,47 +170,54 @@ class Agent extends events.EventEmitter {
                 messageId: packet.messageId
             })
 
-            this._msgInFlight++
-            this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
+            if (this._sock != null) {
+                this._msgInFlight++
+                this._sock.send(buf, 0, buf.length, rsinfo.port, rsinfo.address, ackSent)
+            }
         }
 
-        if (packet.code !== '0.00' && (req._packet.token.length !== packet.token.length || Buffer.compare(req._packet.token, packet.token) !== 0)) {
+        if (packet.code !== '0.00' && (req._packet.token == null || req._packet.token.length !== packet.token.length || Buffer.compare(req._packet.token, packet.token) !== 0)) {
         // The tokens don't match, ignore the message since it is a malformed response
             return
         }
 
         const block1Buff = getOption(packet.options, 'Block1')
-        let block1
-        if (block1Buff) {
+        let block1 = null
+        if (block1Buff instanceof Buffer) {
             block1 = parseBlockOption(block1Buff)
             // check for error
             if (block1 == null) {
                 req.sender.reset()
-                return req.emit('error', new Error('Failed to parse block1'))
+                req.emit('error', new Error('Failed to parse block1'))
+                return
             }
         }
 
         req.sender.reset()
 
-        if (block1 && packet.ack) {
+        if (block1 != null && packet.ack) {
         // If the client takes too long to respond then the retry sender will send
         // another packet with the previous messageId, which we've already removed.
             const segmentedSender = req.segmentedSender
-            if (segmentedSender) {
+            if (segmentedSender != null) {
                 // If there's more to send/receive, then carry on!
                 if (segmentedSender.remaining() > 0) {
-                    if (segmentedSender.isCorrectACK(packet, block1)) {
-                        this._msgIdToReq.delete(req._packet.messageId)
+                    if (segmentedSender.isCorrectACK(block1)) {
+                        if (req._packet.messageId != null) {
+                            this._msgIdToReq.delete(req._packet.messageId)
+                        }
                         req._packet.messageId = this._nextMessageId()
                         this._msgIdToReq.set(req._packet.messageId, req)
-                        segmentedSender.receiveACK(packet, block1)
+                        segmentedSender.receiveACK(block1)
                     } else {
                         segmentedSender.resendPreviousPacket()
                     }
                     return
                 } else {
                     // console.log("Packet received done");
-                    removeOption(req._packet.options, 'Block1')
+                    if (req._packet.options != null) {
+                        removeOption(req._packet.options, 'Block1')
+                    }
                     delete req.segmentedSender
                 }
             }
@@ -229,14 +233,15 @@ class Agent extends events.EventEmitter {
         }
 
         const block2Buff = getOption(packet.options, 'Block2')
-        let block2
+        let block2 = null
         // if we got blockwise (2) response
-        if (block2Buff) {
+        if (block2Buff instanceof Buffer) {
             block2 = parseBlock2(block2Buff)
             // check for error
             if (block2 == null) {
                 req.sender.reset()
-                return req.emit('error', new Error('failed to parse block2'))
+                req.emit('error', new Error('failed to parse block2'))
+                return
             }
         }
         if (block2 != null) {
@@ -252,7 +257,9 @@ class Agent extends events.EventEmitter {
 
             if (block2.more === 1) {
                 // increase message id for next request
-                this._msgIdToReq.delete(req._packet.messageId)
+                if (req._packet.messageId != null) {
+                    this._msgIdToReq.delete(req._packet.messageId)
+                }
                 req._packet.messageId = this._nextMessageId()
                 this._msgIdToReq.set(req._packet.messageId, req)
 
@@ -264,10 +271,11 @@ class Agent extends events.EventEmitter {
                 })
                 if (block2Val == null) {
                     req.sender.reset()
-                    return req.emit('error', new Error('failed to create block2'))
+                    req.emit('error', new Error('failed to create block2'))
+                    return
                 }
                 req.setOption('Block2', block2Val)
-                req._packet.payload = null
+                req._packet.payload = undefined
                 req.sender.send(generate(req._packet))
 
                 return
@@ -279,23 +287,24 @@ class Agent extends events.EventEmitter {
             }
         }
 
-        if (req.response) {
-            if (req.response.append) {
+        if (req.response != null) {
+            const response = req.response
+            if (response.append != null) {
                 // it is an observe request
                 // and we are already streaming
-                return req.response.append(packet)
+                return response.append(packet)
             } else {
                 // TODO There is a previous response but is not an ObserveStream !
                 return
             }
-        } else if (block2) {
+        } else if (block2 != null && packet.token != null) {
             this._tkToReq.delete(packet.token.toString('hex'))
-        } else if (!req.url.observe && !req.multicast) {
-        // it is not, so delete the token
+        } else if (req.url.observe !== true && !req.multicast) {
+            // it is not, so delete the token
             this._tkToReq.delete(packet.token.toString('hex'))
         }
 
-        if (req.url.observe && packet.code !== '4.04') {
+        if (req.url.observe === true && packet.code !== '4.04') {
             response = new ObserveStream(packet, rsinfo, outSocket)
             response.on('close', () => {
                 this._tkToReq.delete(packet.token.toString('hex'))
@@ -345,14 +354,15 @@ class Agent extends events.EventEmitter {
 
     /**
      * Entry point for a new client-side request.
-     * @param {*} url A String representing a CoAP URL, or an object with the appropriate parameters.
+     * @param url The parameters for the request
      */
     request (url) {
         this._init()
 
         const options = url.options || url.headers
-        let option
-        const multicastTimeout = url.multicastTimeout !== undefined ? parseInt(url.multicastTimeout) : 20000
+        const multicastTimeout = url.multicastTimeout != null ? url.multicastTimeout : 20000
+        const host = url.hostname || url.host
+        const port = url.port || parameters.coapPort
 
         const req = new OutgoingMessage({}, (req, packet) => {
             let buf
@@ -381,15 +391,17 @@ class Agent extends events.EventEmitter {
                 if (req.multicast) {
                     this._tkToMulticastResAddr.set(token, [])
                 }
-                if (token) {
+                if (token != null) {
                     this._tkToReq.set(token, req)
                 }
             }
 
-            this._msgIdToReq.set(packet.messageId, req)
+            if (packet.messageId != null) {
+                this._msgIdToReq.set(packet.messageId, req)
+            }
 
             const block1Buff = getOption(packet.options, 'Block1')
-            if (block1Buff) {
+            if (block1Buff != null) {
                 // Setup for a segmented transmission
                 req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet)
                 req.segmentedSender.sendNext()
@@ -400,11 +412,11 @@ class Agent extends events.EventEmitter {
                     req.sender.reset()
                     return req.emit('error', err)
                 }
-                req.sender.send(buf, !packet.confirmable)
+                req.sender.send(buf, packet.confirmable === false)
             }
         })
 
-        req.sender = new RetrySend(this._sock, url.port, url.hostname || url.host, url.retrySend)
+        req.sender = new RetrySend(this._sock, port, host, url.retrySend)
 
         req.url = url
 
@@ -413,15 +425,15 @@ class Agent extends events.EventEmitter {
         this.urlPropertyToPacketOption(url, req, 'pathname', 'Uri-Path', '/')
         this.urlPropertyToPacketOption(url, req, 'query', 'Uri-Query', '&')
 
-        if (options) {
-            for (option in options) {
-                if (Object.prototype.hasOwnProperty.call(options, option)) {
-                    req.setOption(option, options[option])
+        if (options != null) {
+            for (const optionName of Object.keys(options)) {
+                if (optionName in options) {
+                    req.setOption(optionName, options[optionName])
                 }
             }
         }
 
-        if (url.proxyUri) {
+        if (url.proxyUri != null) {
             req.setOption('Proxy-Uri', url.proxyUri)
         }
 
@@ -437,7 +449,9 @@ class Agent extends events.EventEmitter {
         })
 
         req.sender.on('sent', () => {
-            if (req.multicast) return
+            if (req.multicast) {
+                return
+            }
 
             this._msgInFlight--
             if (this._closing && this._msgInFlight === 0) {
@@ -448,12 +462,14 @@ class Agent extends events.EventEmitter {
         // Start multicast monitoring timer in case of multicast request
         if (url.multicast === true) {
             req.multicastTimer = setTimeout(() => {
-                if (req._packet.token) {
+                if (req._packet.token != null) {
                     const token = req._packet.token.toString('hex')
                     this._tkToReq.delete(token)
                     this._tkToMulticastResAddr.delete(token)
                 }
-                this._msgIdToReq.delete(req._packet.messageId)
+                if (req._packet.messageId != null) {
+                    this._msgIdToReq.delete(req._packet.messageId)
+                }
                 this._msgInFlight--
                 if (this._msgInFlight === 0 && this._closing) {
                     this._doClose()
@@ -463,10 +479,10 @@ class Agent extends events.EventEmitter {
 
         if (typeof (url.observe) === 'number') {
             req.setOption('Observe', url.observe)
-        } else if (url.observe) {
-            req.setOption('Observe', null)
-        } else {
+        } else if (url.observe == null) {
             req.on('response', this._cleanUp.bind(this))
+        } else if (url.observe) {
+            req.setOption('Observe', 0)
         }
 
         this._requests++
@@ -480,14 +496,16 @@ class Agent extends events.EventEmitter {
         req.sender.removeAllListeners()
         req.sender.reset()
         this._cleanUp()
-        this._msgIdToReq.delete(req._packet.messageId)
-        if (req._packet.token) {
-            delete this._tkToReq[req._packet.token.toString('hex')]
+        if (req._packet.messageId != null) {
+            this._msgIdToReq.delete(req._packet.messageId)
+        }
+        if (req._packet.token != null) {
+            this._tkToReq.delete(req._packet.token.toString('hex'))
         }
     }
 
     urlPropertyToPacketOption (url, req, property, option, separator) {
-        if (url[property]) {
+        if (url[property] != null) {
             req.setOption(option, url[property].normalize('NFC').split(separator)
                 .filter((part) => { return part !== '' })
                 .map((part) => {
@@ -502,8 +520,9 @@ class Agent extends events.EventEmitter {
         const unicastReq = this.request(req.url)
         const unicastAddress = rsinfo.address.split('%')[0]
         const token = req._packet.token.toString('hex')
-        if (this._tkToMulticastResAddr.get(token).includes(unicastAddress)) {
-            return null
+        const addressArray = this._tkToMulticastResAddr.get(token) || []
+        if (addressArray.includes(unicastAddress)) {
+            return undefined
         }
 
         unicastReq.url.host = unicastAddress
@@ -515,7 +534,7 @@ class Agent extends events.EventEmitter {
                 unicastReq.on(eventName, listener)
             })
         })
-        this._tkToMulticastResAddr.get(token).push(unicastAddress)
+        addressArray.push(unicastAddress)
         unicastReq._packet.token = this._nextToken()
         this._requests++
         return unicastReq

--- a/lib/observe_read_stream.js
+++ b/lib/observe_read_stream.js
@@ -30,6 +30,10 @@ class ObserveReadStream extends IncomingMessage {
             packetToMessage(this, packet)
         }
 
+        if (typeof this.headers.Observe !== 'number') {
+            return
+        }
+
         // First notification
         if (this._lastId === undefined) {
             this._lastId = this.headers.Observe - 1
@@ -48,7 +52,7 @@ class ObserveReadStream extends IncomingMessage {
     close (eagerDeregister) {
         this.push(null)
         this.emit('close')
-        if (eagerDeregister) {
+        if (eagerDeregister === true) {
             this.emit('deregister')
         }
     }

--- a/lib/observe_write_stream.js
+++ b/lib/observe_write_stream.js
@@ -26,13 +26,12 @@ class ObserveWriteStream extends Writable {
 
         this._request = request
         this._send = send
-        this.statusCode = ''
 
         this._counter = 0
 
         this.on('finish', () => {
             if (this._counter === 0) { // we have sent no messages
-                this._doSend(null)
+                this._doSend()
             }
         })
     }
@@ -56,7 +55,7 @@ class ObserveWriteStream extends Writable {
         this._send(this, packet)
 
         this._packet.confirmable = this._request.confirmable
-        this._packet.ack = !this._request.confirmable
+        this._packet.ack = this._request.confirmable === false
         delete this._packet.messageId
         delete this._packet.payload
     }

--- a/lib/option_converter.js
+++ b/lib/option_converter.js
@@ -55,7 +55,7 @@ ignoreOption('Content-Length')
 ignoreOption('Accept-Ranges')
 
 module.exports.isIgnored = (name) => {
-    return !!ignoredOptions[name]
+    return ignoredOptions[name] != null
 }
 
 // ETag option registration
@@ -99,6 +99,12 @@ registerOption('Max-Age', fromUint, toUint)
 const formatsString = {}
 const formatsBinaries = {}
 
+/**
+ * Registers a new Content-Format.
+ *
+ * @param name Media-Type and parameters.
+ * @param value The numeric code of the Content-Format.
+ */
 const registerFormat = (name, value) => {
     let bytes
 
@@ -187,18 +193,19 @@ function contentFormatToString (value) {
         return formatsBinaries[0]
     }
 
+    let numericValue
     if (value.length === 1) {
-        value = value.readUInt8(0)
+        numericValue = value.readUInt8(0)
     } else if (value.length === 2) {
-        value = value.readUInt16BE(0)
+        numericValue = value.readUInt16BE(0)
     } else {
         return null
     }
 
-    const result = formatsBinaries[value]
+    const result = formatsBinaries[numericValue]
 
     if (result == null) {
-        return value
+        return numericValue
     }
 
     return result

--- a/lib/outgoing_message.js
+++ b/lib/outgoing_message.js
@@ -24,7 +24,7 @@ class OutgoingMessage extends BufferList {
             reset: false
         }
 
-        if (request.confirmable) {
+        if (request.confirmable === true) {
         // replying in piggyback
             this._packet.ack = true
 
@@ -54,10 +54,11 @@ class OutgoingMessage extends BufferList {
 
         const packet = this._packet
 
-        packet.code = toCode(this.code || this.statusCode)
+        const code = this.code !== '' ? this.code : this.statusCode
+        packet.code = toCode(code)
         packet.payload = this
 
-        if (this._ackTimer) {
+        if (this._ackTimer != null) {
             clearTimeout(this._ackTimer)
         }
 
@@ -80,7 +81,7 @@ class OutgoingMessage extends BufferList {
         packet.ack = false
         packet.token = Buffer.alloc(0)
 
-        if (this._ackTimer) {
+        if (this._ackTimer != null) {
             clearTimeout(this._ackTimer)
         }
 
@@ -94,12 +95,9 @@ class OutgoingMessage extends BufferList {
 
     writeHead (code, headers) {
         const packet = this._packet
-        let header
         packet.code = String(code).replace(/(^\d[^.])/, '$1.')
-        for (header in headers) {
-            if (Object.prototype.hasOwnProperty.call(headers, header)) {
-                this.setOption(header, headers[header])
-            }
+        for (const [header, value] of Object.entries(headers)) {
+            this.setOption(header, value)
         }
     }
 

--- a/lib/retry_send.js
+++ b/lib/retry_send.js
@@ -8,9 +8,16 @@
  * See the included LICENSE file for more details.
  */
 
-const parameters = require('./parameters').parameters
-const EventEmitter = require('events').EventEmitter
-const parse = require('coap-packet').parse
+const { EventEmitter } = require('events')
+const { parse } = require('coap-packet')
+const { parameters } = require('./parameters')
+
+class RetrySendError extends Error {
+    constructor (retransmitTimeout) {
+        super(`No reply in ${retransmitTimeout} seconds.`)
+        this.retransmitTimeout = retransmitTimeout
+    }
+}
 
 class RetrySend extends EventEmitter {
     constructor (sock, port, host, maxRetransmit) {
@@ -48,7 +55,7 @@ class RetrySend extends EventEmitter {
             this._sendAttemp = 0
         }
 
-        if (!avoidBackoff && ++this._sendAttemp <= this._maxRetransmit) {
+        if (avoidBackoff !== true && ++this._sendAttemp <= this._maxRetransmit) {
             this._bOffTimer = setTimeout(this._bOff, this._currentTime)
         }
 
@@ -59,11 +66,10 @@ class RetrySend extends EventEmitter {
         this._message = message
         this._send(avoidBackoff)
 
-        const timeout = avoidBackoff ? parameters.maxRTT : parameters.exchangeLifetime
+        const timeout = avoidBackoff === true ? parameters.maxRTT : parameters.exchangeLifetime
         this._timer = setTimeout(() => {
-            const err = new Error('No reply in ' + timeout + 's')
-            err.retransmitTimeout = timeout
-            if (!avoidBackoff) {
+            const err = new RetrySendError(timeout)
+            if (avoidBackoff === false) {
                 this.emit('error', err)
             }
             this.emit('timeout', err)

--- a/lib/segmentation.js
+++ b/lib/segmentation.js
@@ -31,10 +31,10 @@ class SegmentedTransmission {
         this.lastByte = 0
 
         this.req = req
-        this.payload = packet.payload
+        this.payload = packet.payload || Buffer.alloc(0)
         this.packet = packet
 
-        this.packet.payload = null
+        this.packet.payload = undefined
         this.resendCount = 0
     }
 
@@ -50,7 +50,7 @@ class SegmentedTransmission {
         this.req.setOption('Block1', generateBlockOption(this.blockState))
     }
 
-    isCorrectACK (packet, retBlockState) {
+    isCorrectACK (retBlockState) {
         return retBlockState.num === this.blockState.num// && packet.code == "2.31"
     }
 
@@ -68,11 +68,10 @@ class SegmentedTransmission {
 
     /**
      *
-     * @param {Packet} packet The packet received which contained the ack
      * @param {Object} retBlockState The received block state from the other end
      * @returns {Boolean} Returns true if the ACK was for the correct block.
      */
-    receiveACK (packet, retBlockState) {
+    receiveACK (retBlockState) {
         if (this.blockState.size !== retBlockState.size) {
             this.setBlockSizeExp(retBlockState.size)
         }
@@ -106,7 +105,8 @@ class SegmentedTransmission {
             buf = generate(this.packet)
         } catch (err) {
             this.req.sender.reset()
-            return this.req.emit('error', err)
+            this.req.emit('error', err)
+            return
         }
         this.req.sender.send(buf, !this.packet.confirmable)
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,27 +8,24 @@
  * See the included LICENSE file for more details.
  */
 
-const dgram = require('dgram')
-const os = require('os')
-const net = require('net')
-const series = require('fastseries')
-const events = require('events')
-const LRU = require('lru-cache')
-const generate = require('coap-packet').generate
-const IncomingMessage = require('./incoming_message')
-const OutgoingMessage = require('./outgoing_message')
-const ObserveStream = require('./observe_write_stream')
-const parameters = require('./parameters').parameters
-const RetrySend = require('./retry_send')
-const parseBlock2 = require('./helpers').parseBlock2
-const createBlock2 = require('./helpers').createBlock2
-const getOption = require('./helpers').getOption
-const isNumeric = require('./helpers').isNumeric
-const isBoolean = require('./helpers').isBoolean
-const middlewares = require('./middlewares')
-const debug = require('debug')('CoAP Server')
-const parseBlockOption = require('./block').parseBlockOption
+const { EventEmitter } = require('events')
+const { isIPv6 } = require('net')
 const BlockCache = require('./cache')
+const OutgoingMessage = require('./outgoing_message')
+const { createSocket, Socket } = require('dgram')
+const LRU = require('lru-cache')
+const os = require('os')
+const IncomingMessage = require('./incoming_message')
+const ObserveStream = require('./observe_write_stream')
+const RetrySend = require('./retry_send')
+const { handleProxyResponse, handleServerRequest, parseRequest, proxyRequest } = require('./middlewares')
+const { parseBlockOption } = require('./block')
+const { generate } = require('coap-packet')
+const { parseBlock2, createBlock2, getOption, isNumeric, isBoolean } = require('./helpers')
+const { parameters } = require('./parameters')
+const series = require('fastseries')
+const Debug = require('debug')
+const debug = Debug('CoAP Server')
 
 function handleEnding (err) {
     const request = this
@@ -43,11 +40,16 @@ function handleEnding (err) {
 
 function removeProxyOptions (packet) {
     const cleanOptions = []
+    if (packet.options == null) {
+        packet.options = []
+    }
 
     for (let i = 0; i < packet.options.length; i++) {
+        const optionName = packet.options[i].name
         if (
-            packet.options[i].name.toLowerCase() !== 'proxy-uri' &&
-            packet.options[i].name.toLowerCase() !== 'proxy-scheme'
+            typeof optionName === 'string' &&
+            optionName.toLowerCase() !== 'proxy-uri' &&
+            optionName.toLowerCase() !== 'proxy-scheme'
         ) {
             cleanOptions.push(packet.options[i])
         }
@@ -58,23 +60,6 @@ function removeProxyOptions (packet) {
     return packet
 }
 
-function handleRequest (server) {
-    return (msg, rsinfo) => {
-        const request = {
-            raw: msg,
-            rsinfo: rsinfo,
-            server: server
-        }
-        const activeMiddlewares = []
-
-        for (let i = 0; i < server._middlewares.length; i++) {
-            activeMiddlewares.push(server._middlewares[i])
-        }
-
-        server._series(request, activeMiddlewares, request, handleEnding)
-    }
-}
-
 function allAddresses (type) {
     let family = 'IPv4'
     if (type === 'udp6') {
@@ -83,7 +68,7 @@ function allAddresses (type) {
     const addresses = []
     const interfaces = os.networkInterfaces()
     for (const ifname in interfaces) {
-        if (Object.prototype.hasOwnProperty.call(interfaces, ifname)) {
+        if (ifname in interfaces) {
             interfaces[ifname].forEach((a) => {
                 if (a.family === family) {
                     addresses.push(a.address)
@@ -94,38 +79,34 @@ function allAddresses (type) {
     return addresses
 }
 
-class CoAPServer extends events.EventEmitter {
-    constructor (options, listener) {
+class CoAPServer extends EventEmitter {
+    constructor (serverOptions, listener) {
         super()
-        if (typeof options === 'function') {
-            listener = options
-            options = null
-        }
-
-        if (options == null) {
-            options = {}
-        }
-
-        this._options = options
+        this._options = {}
         this._proxiedRequests = new Map()
-
-        this._middlewares = [middlewares.parseRequest]
-
-        if (options.proxy) {
-            this._middlewares.push(middlewares.proxyRequest)
-            this._middlewares.push(middlewares.handleProxyResponse)
+        if (typeof serverOptions === 'function') {
+            listener = serverOptions
+        } else if (serverOptions != null) {
+            this._options = serverOptions
         }
 
-        if (typeof options.clientIdentifier === 'function') {
-            this._clientIdentifier = options.clientIdentifier
-        } else {
-            this._clientIdentifier = (request) => {
+        this._middlewares = [parseRequest]
+
+        if (this._options.proxy === true) {
+            this._middlewares.push(proxyRequest)
+            this._middlewares.push(handleProxyResponse)
+        }
+
+        if (typeof this._options.clientIdentifier !== 'function') {
+            this._options.clientIdentifier = (request) => {
                 return `${request.rsinfo.address}:${request.rsinfo.port}`
             }
         }
 
+        this._clientIdentifier = this._options.clientIdentifier
+
         if (
-            !this._options.piggybackReplyMs ||
+            (this._options.piggybackReplyMs == null) ||
             !isNumeric(this._options.piggybackReplyMs)
         ) {
             this._options.piggybackReplyMs = parameters.piggybackReplyMs
@@ -135,14 +116,14 @@ class CoAPServer extends events.EventEmitter {
             this._options.sendAcksForNonConfirmablePackets =
                 parameters.sendAcksForNonConfirmablePackets
         }
-        this._middlewares.push(middlewares.handleServerRequest)
+        this._middlewares.push(handleServerRequest)
 
         // Multicast settings
-        this._multicastAddress = options.multicastAddress
-            ? options.multicastAddress
+        this._multicastAddress = (this._options.multicastAddress != null)
+            ? this._options.multicastAddress
             : null
-        this._multicastInterface = options.multicastInterface
-            ? options.multicastInterface
+        this._multicastInterface = (this._options.multicastInterface != null)
+            ? this._options.multicastInterface
             : null
 
         // We use an LRU cache for the responses to avoid
@@ -153,18 +134,20 @@ class CoAPServer extends events.EventEmitter {
         // Which gave us 131 packets/second guarantee
         let max = 32768 * 1024
 
-        if (typeof options.cacheSize === 'number' && options.cacheSize >= 0) {
-            max = options.cacheSize
+        if (typeof this._options.cacheSize === 'number' && this._options.cacheSize >= 0) {
+            max = this._options.cacheSize
         }
 
         this._lru = new LRU({
             max,
-            length: (n) => {
+            length: (n, key) => {
                 return n.buffer.byteLength
             },
             maxAge: parameters.exchangeLifetime * 1000,
             dispose: (key, value) => {
-                if (value.sender) value.sender.reset()
+                if (value.sender != null) {
+                    value.sender.reset()
+                }
             }
         })
 
@@ -183,28 +166,51 @@ class CoAPServer extends events.EventEmitter {
             }
         )
 
-        if (listener) this.on('request', listener)
+        if (listener != null) {
+            this.on('request', listener)
+        }
         debug('initialized')
+    }
+
+    handleRequest () {
+        return (msg, rsinfo) => {
+            const request = {
+                raw: msg,
+                rsinfo: rsinfo,
+                server: this
+            }
+            const activeMiddlewares = []
+
+            for (let i = 0; i < this._middlewares.length; i++) {
+                activeMiddlewares.push(this._middlewares[i])
+            }
+
+            this._series(request, activeMiddlewares, request, handleEnding)
+        }
     }
 
     _sendError (payload, rsinfo, packet, code = '5.00') {
         const message = generate({
             code,
             payload: payload,
-            messageId: packet ? packet.messageId : undefined,
-            token: packet ? packet.token : undefined
+            messageId: packet != null ? packet.messageId : undefined,
+            token: packet != null ? packet.token : undefined
         })
 
-        this._sock.send(message, 0, message.length, rsinfo.port)
+        if (this._sock instanceof Socket) {
+            this._sock.send(message, rsinfo.port, rsinfo.host)
+        }
     }
 
     _sendProxied (packet, proxyUri, callback) {
         const url = new URL(proxyUri)
         const host = url.hostname
-        const port = url.port
+        const port = parseInt(url.port)
         const message = generate(removeProxyOptions(packet))
 
-        this._sock.send(message, 0, message.length, port, host, callback)
+        if (this._sock instanceof Socket) {
+            this._sock.send(message, port, host, callback)
+        }
     }
 
     _sendReverseProxied (packet, rsinfo, callback) {
@@ -212,32 +218,81 @@ class CoAPServer extends events.EventEmitter {
         const port = rsinfo.port
         const message = generate(packet)
 
-        this._sock.send(message, 0, message.length, port, host, callback)
+        if (this._sock instanceof Socket) {
+            this._sock.send(message, port, host, callback)
+        }
     }
 
-    listen (port, address, done) {
-        if (port == null) {
+    generateSocket (address, port, done) {
+        const socketOptions = {
+            type: this._options.type || 'udp4',
+            reuseAddr: this._options.reuseAddr
+        }
+        const sock = createSocket(socketOptions)
+        sock.bind(port, address, () => {
+            try {
+                if (this._multicastAddress != null) {
+                    const multicastAddress = this._multicastAddress
+                    sock.setMulticastLoopback(true)
+                    if (this._multicastInterface != null) {
+                        sock.addMembership(
+                            multicastAddress,
+                            this._multicastInterface
+                        )
+                    } else {
+                        allAddresses(this._options.type).forEach((
+                            _interface
+                        ) => {
+                            sock.addMembership(
+                                multicastAddress,
+                                _interface
+                            )
+                        })
+                    }
+                }
+            } catch (err) {
+                if (done != null) {
+                    return done(err)
+                } else {
+                    throw err
+                }
+            }
+
+            if (done != null) {
+                return done()
+            }
+        })
+
+        return sock
+    }
+
+    listen (portOrCallback, addressOrCallback, done) {
+        let port = parameters.coapPort
+        if (typeof portOrCallback === 'function') {
+            done = portOrCallback
             port = parameters.coapPort
+        } else if (typeof portOrCallback === 'number') {
+            port = portOrCallback
         }
 
-        if (typeof port === 'function') {
-            done = port
-            port = parameters.coapPort
+        let address
+        if (typeof addressOrCallback === 'function') {
+            done = addressOrCallback
+        } else if (typeof addressOrCallback === 'string') {
+            address = addressOrCallback
         }
 
-        if (typeof address === 'function') {
-            done = address
-            address = null
-        }
-
-        if (this._sock) {
-            if (done) done(new Error('Already listening'))
-            else throw new Error('Already listening')
+        if (this._sock != null) {
+            if (done != null) {
+                done(new Error('Already listening'))
+            } else {
+                throw new Error('Already listening')
+            }
 
             return this
         }
 
-        if (address != null && net.isIPv6(address)) {
+        if (address != null && isIPv6(address)) {
             this._options.type = 'udp6'
         }
 
@@ -249,58 +304,28 @@ class CoAPServer extends events.EventEmitter {
             this._options.reuseAddr = true
         }
 
-        if (port instanceof events.EventEmitter) {
-            this._sock = port
-            if (done) setImmediate(done)
+        if (portOrCallback instanceof EventEmitter) {
+            this._sock = portOrCallback
+            if (done != null) {
+                setImmediate(done)
+            }
         } else {
             this._internal_socket = true
-            this._sock = dgram.createSocket({
-                type: this._options.type,
-                reuseAddr: this._options.reuseAddr
-            })
-
-            this._sock.bind(port, address || null, () => {
-                try {
-                    if (this._multicastAddress) {
-                        this._sock.setMulticastLoopback(true)
-
-                        if (this._multicastInterface) {
-                            this._sock.addMembership(
-                                this._multicastAddress,
-                                this._multicastInterface
-                            )
-                        } else {
-                            allAddresses(this._options.type).forEach((
-                                _interface
-                            ) => {
-                                this._sock.addMembership(
-                                    this._multicastAddress,
-                                    _interface
-                                )
-                            })
-                        }
-                    }
-                } catch (err) {
-                    if (done) return done(err)
-                    else throw err
-                }
-
-                if (done) return done()
-            })
+            this._sock = this.generateSocket(address, port, done)
         }
 
-        this._sock.on('message', handleRequest(this))
+        this._sock.on('message', this.handleRequest())
 
         this._sock.on('error', (error) => {
             this.emit('error', error)
         })
 
-        if (parameters.pruneTimerPeriod) {
+        if (parameters.pruneTimerPeriod != null) {
             // Start LRU pruning timer
             this._lru.pruneTimer = setInterval(() => {
                 this._lru.prune()
             }, parameters.pruneTimerPeriod * 1000)
-            if (this._lru.pruneTimer.unref) {
+            if (this._lru.pruneTimer.unref != null) {
                 this._lru.pruneTimer.unref()
             }
         }
@@ -309,16 +334,16 @@ class CoAPServer extends events.EventEmitter {
     }
 
     close (done) {
-        if (done) {
+        if (done != null) {
             setImmediate(done)
         }
 
-        if (this._lru.pruneTimer) {
+        if (this._lru.pruneTimer != null) {
             clearInterval(this._lru.pruneTimer)
         }
 
-        if (this._sock) {
-            if (this._internal_socket) {
+        if (this._sock != null) {
+            if (this._internal_socket && this._sock instanceof Socket) {
                 this._sock.close()
             }
             this._lru.reset()
@@ -340,7 +365,7 @@ class CoAPServer extends events.EventEmitter {
      * @param {Object} rsinfo Connection info
      */
     _handle (packet, rsinfo) {
-        if (packet.code[0] !== '0') {
+        if (packet.code == null || packet.code[0] !== '0') {
             // According to RFC7252 Section 4.2 receiving a confirmable messages
             // that can't be processed, should be rejected by ignoring it AND
             // sending a reset. In this case confirmable response message would
@@ -356,10 +381,10 @@ class CoAPServer extends events.EventEmitter {
         const request = new IncomingMessage(packet, rsinfo)
         const cached = lru.peek(this._toKey(request, packet, true))
 
-        if (cached && !packet.ack && !packet.reset) {
+        if (cached != null && !packet.ack && !packet.reset && sock instanceof Socket) {
             return sock.send(cached, 0, cached.length, rsinfo.port, rsinfo.address)
-        } else if (cached && (packet.ack || packet.reset)) {
-            if (cached.response && packet.reset) {
+        } else if (cached != null && (packet.ack || packet.reset)) {
+            if (cached.response != null && packet.reset) {
                 cached.response.end()
             }
             return lru.del(this._toKey(request, packet, false))
@@ -371,10 +396,11 @@ class CoAPServer extends events.EventEmitter {
             Message = ObserveStream
             if (packet.code !== '0.01' && packet.code !== '0.05') {
                 // it is neither a GET nor a FETCH
-                return this._sendError(
+                this._sendError(
                     Buffer.from('Observe can only be present with a GET or a FETCH'),
                     rsinfo
                 )
+                return
             }
         }
 
@@ -382,7 +408,7 @@ class CoAPServer extends events.EventEmitter {
             return this._sendError(
                 Buffer.from('FETCH requests must contain a Content-Format option'),
                 rsinfo,
-                null,
+                undefined,
                 '4.15' /* TODO: Check if this is the correct error code */
             )
         }
@@ -398,7 +424,8 @@ class CoAPServer extends events.EventEmitter {
                 try {
                     buf = generate(packet)
                 } catch (err) {
-                    return response.emit('error', err)
+                    response.emit('error', err)
+                    return
                 }
                 if (Message === OutMessage) {
                     sender.on('error', response.emit.bind(response, 'error'))
@@ -418,12 +445,12 @@ class CoAPServer extends events.EventEmitter {
                 buf.sender = sender
 
                 if (
-                    this._options.sendAcksForNonConfirmablePackets ||
+                    this._options.sendAcksForNonConfirmablePackets === true ||
                     packet.confirmable
                 ) {
                     sender.send(
                         buf,
-                        packet.ack || packet.reset || packet.confirmable === false
+                        packet.ack || packet.reset || !packet.confirmable
                     )
                 } else {
                     debug('OMIT ACK PACKAGE')
@@ -432,7 +459,9 @@ class CoAPServer extends events.EventEmitter {
 
             response.statusCode = '2.05'
             response._request = request._packet
-            response._cachekey = cacheKey
+            if (cacheKey != null) {
+                response._cachekey = cacheKey
+            }
 
             // inject this function so the response can add an entry to the cache
             response._addCacheEntry = this._block2Cache.add.bind(this._block2Cache)
@@ -443,18 +472,19 @@ class CoAPServer extends events.EventEmitter {
         const response = generateResponse()
         request.rsinfo = rsinfo
 
-        if (packet.token && packet.token.length > 0) {
+        if (packet.token != null && packet.token.length > 0) {
             // return cached value only if this request is not the first block request
             const block2Buff = getOption(packet.options, 'Block2')
             let requestedBlockOption
-            if (block2Buff) {
+            if (block2Buff instanceof Buffer) {
                 requestedBlockOption = parseBlock2(block2Buff)
             }
             if (requestedBlockOption == null) {
                 requestedBlockOption = { num: 0 }
             }
-
-            if (requestedBlockOption.num < 1) {
+            if (cacheKey == null) {
+                return
+            } else if (requestedBlockOption.num < 1) {
                 if (this._block2Cache.remove(cacheKey)) {
                     debug('first block2 request, removed old entry from cache')
                 }
@@ -462,70 +492,75 @@ class CoAPServer extends events.EventEmitter {
                 debug('check if packet token is in cache, key:', cacheKey)
                 if (this._block2Cache.contains(cacheKey)) {
                     debug('found cached payload, key:', cacheKey)
-                    response.end(this._block2Cache.get(cacheKey))
+                    if (response != null) {
+                        response.end(this._block2Cache.get(cacheKey))
+                    }
                     return
                 }
             }
         }
-        // else goes here?
-        {
-            const block1Buff = getOption(packet.options, 'Block1')
-            if (block1Buff) {
-                const blockState = parseBlockOption(block1Buff)
 
-                if (blockState) {
-                    /** @type {{[k:string]:Buffer}} */
-                    const cachedData =
-                        this._block1Cache.getWithDefaultInsert(cacheKey)
-                    const blockByteSize = Math.pow(2, 4 + blockState.size)
-                    const incomingByteIndex = blockState.num * blockByteSize
-                    // Store in the cache object, use the byte index as the key
-                    cachedData[incomingByteIndex] = request.payload
+        const block1Buff = getOption(packet.options, 'Block1')
+        if (block1Buff instanceof Buffer) {
+            const blockState = parseBlockOption(block1Buff)
 
-                    if (blockState.more === 0) {
-                        // Last block
-                        const byteOffsets = Object.keys(cachedData)
-                            .map((str) => {
-                                return parseInt(str)
-                            })
-                            .sort((a, b) => {
-                                return a - b
-                            })
-                        const byteTotalSum =
-                            incomingByteIndex + request.payload.length
-                        let next = 0
-                        const concat = Buffer.alloc(byteTotalSum)
-                        for (let i = 0; i < byteOffsets.length; i++) {
-                            if (byteOffsets[i] === next) {
-                                const buff = cachedData[byteOffsets[i]]
-                                buff.copy(concat, next, 0, buff.length)
-                                next += buff.length
-                            } else {
-                                throw new Error(
-                                    'Byte offset not the next in line...'
-                                )
+            if (blockState != null) {
+                const cachedData = this._block1Cache.getWithDefaultInsert(cacheKey)
+                const blockByteSize = Math.pow(2, 4 + blockState.size)
+                const incomingByteIndex = blockState.num * blockByteSize
+                // Store in the cache object, use the byte index as the key
+                cachedData[incomingByteIndex] = request.payload
+
+                if (blockState.more === 0) {
+                    // Last block
+                    const byteOffsets = Object.keys(cachedData)
+                        .map((str) => {
+                            return parseInt(str)
+                        })
+                        .sort((a, b) => {
+                            return a - b
+                        })
+                    const byteTotalSum =
+                        incomingByteIndex + request.payload.length
+                    let next = 0
+                    const concat = Buffer.alloc(byteTotalSum)
+                    for (let i = 0; i < byteOffsets.length; i++) {
+                        if (byteOffsets[i] === next) {
+                            const buff = cachedData[byteOffsets[i]]
+                            if (!(buff instanceof Buffer)) {
+                                continue
                             }
-                        }
-
-                        this._block1Cache.remove(cacheKey)
-
-                        if (next === concat.length) {
-                            request.payload = concat
+                            buff.copy(concat, next, 0, buff.length)
+                            next += buff.length
                         } else {
                             throw new Error(
-                                'Last byte index is not equal to the concat buffer length!'
+                                'Byte offset not the next in line...'
                             )
                         }
+                    }
+
+                    if (cacheKey != null) {
+                        this._block1Cache.remove(cacheKey)
+                    }
+
+                    if (next === concat.length) {
+                        request.payload = concat
                     } else {
-                        // More blocks to come. ACK this block
+                        throw new Error(
+                            'Last byte index is not equal to the concat buffer length!'
+                        )
+                    }
+                } else {
+                    // More blocks to come. ACK this block
+                    if (response != null) {
                         response.code = '2.31'
                         response.setOption('Block1', block1Buff)
                         response.end()
-                        return
                     }
-                } else {
-                    throw new Error('Invalid block state' + blockState)
+                    return
                 }
+            } else {
+                throw new Error('Invalid block state' + blockState)
             }
         }
 
@@ -533,7 +568,7 @@ class CoAPServer extends events.EventEmitter {
     }
 
     _toCacheKey (request, packet) {
-        if (packet.token && packet.token.length > 0) {
+        if (packet.token != null && packet.token.length > 0) {
             return `${packet.token.toString('hex')}/${this._clientIdentifier(
                 request
             )}`
@@ -543,9 +578,15 @@ class CoAPServer extends events.EventEmitter {
     }
 
     _toKey (request, packet, appendToken) {
-        let result = `${this._clientIdentifier(request)}/${packet.messageId}`
+        let result = this._clientIdentifier(request)
 
-        if (appendToken) result += packet.token.toString('hex')
+        if (packet.messageId != null) {
+            result += `/${packet.messageId}`
+        }
+
+        if (appendToken && packet.token != null) {
+            result += packet.token.toString('hex')
+        }
 
         return result
     }
@@ -575,10 +616,12 @@ class OutMessage extends OutgoingMessage {
         // add logic for Block1 sending
 
         const block2Buff = getOption(this._request.options, 'Block2')
-        let requestedBlockOption
+        let requestedBlockOption = null
         // if we got blockwise (2) request
-        if (block2Buff) {
-            requestedBlockOption = parseBlock2(block2Buff)
+        if (block2Buff != null) {
+            if (block2Buff instanceof Buffer) {
+                requestedBlockOption = parseBlock2(block2Buff)
+            }
             // bad option
             if (requestedBlockOption == null) {
                 this.statusCode = '4.02'
@@ -598,6 +641,7 @@ class OutMessage extends OutgoingMessage {
         if (requestedBlockOption == null) {
             requestedBlockOption = {
                 size: maxBlock2,
+                more: 1,
                 num: 0
             }
         }
@@ -625,13 +669,13 @@ class OutMessage extends OutgoingMessage {
             // this catch never be match,
             // since we're gentleman, just handle it
             this.statusCode = '4.02'
-            super.end()
+            return super.end()
         }
         this.setOption('Block2', block2)
         this.setOption('ETag', _toETag(payload))
 
         // cache it
-        if (this._request.token && this._request.token.length > 0) {
+        if (this._request.token != null && this._request.token.length > 0) {
             this._addCacheEntry(this._cachekey, payload)
         }
         super.end(
@@ -640,6 +684,8 @@ class OutMessage extends OutgoingMessage {
                 (requestedBlockOption.num + 1) * requestedBlockOption.size
             )
         )
+
+        return this
     }
 }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -8,24 +8,22 @@
 
 const { nextPort } = require('./common')
 
-const coap = require('../')
-const parse = require('coap-packet').parse
-const generate = require('coap-packet').generate
-const dgram = require('dgram')
-const request = coap.request
+const { Agent, request } = require('../index')
+const { parse, generate } = require('coap-packet')
+const { createSocket } = require('dgram')
 const { expect } = require('chai')
 
 describe('Agent config', function () {
     it('should get agent instance through custom config', function (done) {
-        const agent = new coap.Agent({ type: 'udp4', port: 62754 })
+        const agent = new Agent({ type: 'udp4', port: 62754 })
         expect(agent._sock.type).to.eql('udp4')
         expect(agent._sock._bindState).to.eql(1)
         done()
     })
 
     it('should get agent instance through custom socket', function (done) {
-        const socket = dgram.createSocket('udp6')
-        const agent = new coap.Agent({ socket, type: 'udp4', port: 62754 })
+        const socket = createSocket('udp6')
+        const agent = new Agent({ socket, type: 'udp4', port: 62754 })
         expect(agent._opts.type).to.eql('udp6')
         expect(agent._sock.type).to.eql('udp6')
         expect(agent._sock._bindState).to.eql(0)
@@ -40,8 +38,8 @@ describe('Agent', function () {
 
     beforeEach(function (done) {
         port = nextPort()
-        agent = new coap.Agent()
-        server = dgram.createSocket('udp4')
+        agent = new Agent()
+        server = createSocket('udp4')
         server.bind(port, done)
     })
 
@@ -50,10 +48,6 @@ describe('Agent', function () {
     })
 
     function doReq (confirmable) {
-        if (confirmable == null) {
-            confirmable = false
-        }
-
         return request({
             port: port,
             agent: agent,
@@ -336,7 +330,7 @@ describe('Agent', function () {
                 break
             }
             case 2:
-                expect(packet.reset).to.be.true // eslint-disable-line no-unused-expressions
+                expect(packet.reset).to.be.eql(true)
                 done()
                 break
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -12,7 +12,7 @@ const BlockCache = require('../lib/cache')
 describe('Cache', () => {
     describe('Block Cache', () => {
         it('Should set up empty cache object', (done) => {
-            const b = new BlockCache()
+            const b = new BlockCache(10000, () => { return {} })
             expect(b._cache.size).to.eql(0)
             setImmediate(done)
         })
@@ -32,7 +32,7 @@ describe('Cache', () => {
         it('Should add to cache', (done) => {
             const b = new BlockCache(10000, () => { return null })
             b.add('test', { payload: 'test' })
-            expect(b._cache.has('test')).to.equal(true)
+            expect(b.contains('test')).to.equal(true)
             setImmediate(done)
         })
     // reuse old cache entry
@@ -44,7 +44,7 @@ describe('Cache', () => {
             b.add('test', { payload: 'test' })
             b.add('test2', { payload: 'test2' })
             b.remove('test')
-            expect(b._cache.has('test')).to.equal(false)
+            expect(b.contains('test')).to.equal(false)
             setImmediate(done)
         })
     })
@@ -74,7 +74,7 @@ describe('Cache', () => {
         })
     })
 
-    describe('Get Witgh Default Insert', () => {
+    describe('Get with default insert', () => {
         it('Should return payload from cache if it exists', (done) => {
             const b = new BlockCache(10000, () => { return null })
             b.add('test', { payload: 'test' })
@@ -82,10 +82,10 @@ describe('Cache', () => {
             setImmediate(done)
         })
 
-        it('Should add to cache if it doesnt exist', (done) => {
+        it('Should add to cache if it does not exist', (done) => {
             const b = new BlockCache(10000, () => { return null })
             b.getWithDefaultInsert('test')
-            expect(b._cache.has('test')).to.equal(true)
+            expect(b.contains('test')).to.equal(true)
             setImmediate(done)
         })
     })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,13 +6,8 @@
  * See the included LICENSE file for more details.
  */
 
-const toCode = require('../lib/helpers').toCode
-const getOption = require('../lib/helpers').getOption
-const hasOption = require('../lib/helpers').hasOption
-const removeOption = require('../lib/helpers').removeOption
-const parseBlock2 = require('../lib/helpers').parseBlock2
-const createBlock2 = require('../lib/helpers').createBlock2
 const { expect } = require('chai')
+const { toCode, getOption, hasOption, removeOption, parseBlock2, createBlock2 } = require('../lib/helpers')
 
 describe('Helpers', () => {
     describe('Has Options', () => {
@@ -76,8 +71,10 @@ describe('Helpers', () => {
         it('Should have case 3 equal 4128', (done) => {
             const buff = Buffer.from([0x01, 0x02, 0x03])
             const res = parseBlock2(buff)
-            expect(res.num).to.eql(4128)
-            setImmediate(done)
+            if (res != null) {
+                expect(res.num).to.eql(4128)
+                setImmediate(done)
+            }
         })
 
         it('Should return null', (done) => {

--- a/test/ipv6.js
+++ b/test/ipv6.js
@@ -7,24 +7,22 @@
  */
 
 const { nextPort } = require('./common')
-
-const coap = require('../')
-const parse = require('coap-packet').parse
-const generate = require('coap-packet').generate
-const dgram = require('dgram')
 const { expect } = require('chai')
+const { parse, generate } = require('coap-packet')
+const { createSocket } = require('dgram')
+const { createServer, request } = require('../index')
 
 describe('IPv6', function () {
     describe('server', function () {
-        let server,
-            port,
-            clientPort,
-            client
+        let server
+        let port
+        let clientPort
+        let client
 
         beforeEach(function (done) {
             port = nextPort()
             clientPort = nextPort()
-            client = dgram.createSocket('udp6')
+            client = createSocket('udp6')
             client.bind(clientPort, done)
         })
 
@@ -38,7 +36,7 @@ describe('IPv6', function () {
         }
 
         it('should receive a CoAP message specifying the type', function (done) {
-            server = coap.createServer({ type: 'udp6' })
+            server = createServer({ type: 'udp6' })
             server.listen(port, () => {
                 send(generate({}))
                 server.on('request', (req, res) => {
@@ -48,7 +46,7 @@ describe('IPv6', function () {
         })
 
         it('should automatically discover the type based on the host', function (done) {
-            server = coap.createServer()
+            server = createServer()
             server.listen(port, '::1', () => {
                 send(generate({}))
                 server.on('request', (req, res) => {
@@ -59,24 +57,22 @@ describe('IPv6', function () {
     })
 
     describe('request', function () {
-        let server,
-            port
+        let server
+        let port
 
         beforeEach(function (done) {
             port = nextPort()
-            server = dgram.createSocket('udp6')
+            server = createSocket('udp6')
             server.bind(port, done)
         })
 
         afterEach(function () {
             server.close()
-
-            server = null
         })
 
         function createTest (createUrl) {
             return function (done) {
-                const req = coap.request(createUrl())
+                const req = request(createUrl())
                 req.end(Buffer.from('hello world'))
 
                 server.on('message', (msg, rsinfo) => {
@@ -110,17 +106,17 @@ describe('IPv6', function () {
     })
 
     describe('end-to-end', function () {
-        let server,
-            port
+        let server
+        let port
 
         beforeEach(function (done) {
             port = nextPort()
-            server = coap.createServer({ type: 'udp6' })
+            server = createServer({ type: 'udp6' })
             server.listen(port, done)
         })
 
         it('should receive a request at a path with some query', function (done) {
-            coap.request(`coap://[::1]:${port}/abcd/ef/gh/?foo=bar&beep=bop`).end()
+            request(`coap://[::1]:${port}/abcd/ef/gh/?foo=bar&beep=bop`).end()
             server.on('request', (req) => {
                 expect(req.url).to.eql('/abcd/ef/gh?foo=bar&beep=bop')
                 done()

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -6,18 +6,17 @@
  * See the included LICENSE file for more details.
  */
 
-const coap = require('../')
-const parameters = coap.parameters
+const { parameters, defaultTiming, updateTiming } = require('../index')
 const { expect } = require('chai')
 
 describe('Parameters', function () {
     afterEach(function () {
-        parameters.defaultTiming()
+        defaultTiming()
     })
 
     it('should ignore empty parameter', function () {
     // WHEN
-        coap.updateTiming()
+        updateTiming()
 
         // THEN
         expect(parameters.maxRTT).to.eql(202)
@@ -37,7 +36,7 @@ describe('Parameters', function () {
         }
 
         // WHEN
-        coap.updateTiming(coapTiming)
+        updateTiming(coapTiming)
 
         // THEN
         expect(parameters.maxRTT).to.eql(11)


### PR DESCRIPTION
This PR adds most of the `null` and type checks from #293 to the current state of the project to further decrease diff size. The project should also already benefit a little from the changes in terms of stability and readability. For most part, the changes are rather trivial, though.