### PR TITLE
chore: ignore test files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,5 @@ coverage
 .github
 .mocharc.json
 .nycrc.json
+dist/test
+test


### PR DESCRIPTION
This PR is a potential fix for the problem that tests files end up on npm. The change to the `.npmignore` file should prevent that in the future.