### PR TITLE
feat(agent): add `close` method

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -103,6 +103,16 @@ class Agent extends EventEmitter {
         this._requests = 0
     }
 
+    close (done?: (err?: Error) => void): this {
+        for (const req of this._msgIdToReq.values()) {
+            this.abort(req)
+        }
+        if (done != null) {
+            setImmediate(done)
+        }
+        return this
+    }
+
     _cleanUp (): void {
         if (--this._requests !== 0) {
             return
@@ -132,6 +142,7 @@ class Agent extends EventEmitter {
             this._sock.close()
         }
         this._sock = null
+        this.emit('close')
     }
 
     _handle (packet: ParsedPacket, rsinfo: AddressInfo, outSocket: AddressInfo): void {

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -505,6 +505,7 @@ class Agent extends EventEmitter {
     abort (req: OutgoingMessage): void {
         req.sender.removeAllListeners()
         req.sender.reset()
+        this._msgInFlight--
         this._cleanUp()
         if (req._packet.messageId != null) {
             this._msgIdToReq.delete(req._packet.messageId)

--- a/test/agent.ts
+++ b/test/agent.ts
@@ -60,6 +60,31 @@ describe('Agent', function () {
         }).end()
     }
 
+    it('should allow to close the agent', function (done) {
+        let closeEmitted = false
+        const port = nextPort()
+        // Initiate a number of requests
+        doReq(undefined, port)
+        doReq(undefined, port)
+        doReq(undefined, port)
+        doReq(undefined, port)
+
+        agent.on('close', () => {
+            closeEmitted = true
+            expect(agent._requests).to.equal(0)
+            expect(agent._sock).to.equal(null)
+        })
+
+        agent.close()
+
+        // Ensure that new requests can still be sent
+        doReq()
+        server.on('message', (msg, rsinfo) => {
+            expect(closeEmitted).to.equal(true)
+            agent.close(done)
+        })
+    })
+
     it('should reuse the same socket for multiple requests', function (done) {
         let firstRsinfo
 

--- a/test/agent.ts
+++ b/test/agent.ts
@@ -48,11 +48,15 @@ describe('Agent', function () {
         server.close()
     })
 
-    function doReq (confirmable?: boolean): OutgoingMessage {
+    function doReq (confirmable?: boolean, customPort?: number): OutgoingMessage {
+        let requestPort = port
+        if (customPort != null) {
+            requestPort = customPort
+        }
         return request({
-            port: port,
-            agent: agent,
-            confirmable: confirmable
+            port: requestPort,
+            agent,
+            confirmable
         }).end()
     }
 

--- a/test/server.ts
+++ b/test/server.ts
@@ -1000,14 +1000,14 @@ describe('server', function () {
     describe('multicast', function () {
         const port = nextPort()
 
-        it('receive CoAp message', function (done) {
+        it('receive CoAP message', function (done) {
             const server = createServer({
                 multicastAddress: '224.0.1.2'
             })
 
             server.listen(port)
 
-            server.on('request', (msg) => {
+            server.once('request', (req, res) => {
                 done()
             })
 


### PR DESCRIPTION
This PR adds a `close` method to the `Agent` class that aborts all pending requests and resolves #312. To do so, a small bug is fixed in the `abort` method where the `_msgInFlight` hasn't been decremented when a request is cancelled.

An additional test is added to assert that the new method works as expected.