### PR TITLE
fix(index.ts): fix issues with exported types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,8 @@ import Agent from './lib/agent'
 import Server from './lib/server'
 import IncomingMessage from './lib/incoming_message'
 import OutgoingMessage from './lib/outgoing_message'
-import ObserveReadStream = require('./lib/observe_read_stream')
-import ObserveWriteStream = require('./lib/observe_write_stream')
+import ObserveReadStream from './lib/observe_read_stream'
+import ObserveWriteStream from './lib/observe_write_stream'
 import { parameters, refreshTiming, defaultTiming } from './lib/parameters'
 import { isIPv6 } from 'net'
 import { registerOption, registerFormat, ignoreOption } from './lib/option_converter'

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import ObserveWriteStream = require('./lib/observe_write_stream')
 import { parameters, refreshTiming, defaultTiming } from './lib/parameters'
 import { isIPv6 } from 'net'
 import { registerOption, registerFormat, ignoreOption } from './lib/option_converter'
-import { CoapServerOptions, requestListener, CoapRequestParams, ParametersUpdate } from './models/models'
+import { CoapServerOptions, requestListener, CoapRequestParams, ParametersUpdate, AgentOptions } from './models/models'
 
 export let globalAgent = new Agent({ type: 'udp4' })
 export let globalAgentIPv6 = new Agent({ type: 'udp6' })
@@ -98,5 +98,7 @@ export {
     ObserveWriteStream,
     Agent,
     Server,
-    ParametersUpdate
+    ParametersUpdate,
+    CoapRequestParams,
+    AgentOptions
 }


### PR DESCRIPTION
This PR makes some small adjustments to `index.ts` where a couple of definitions weren't exported correctly. I think we could publish a (patch) version `1.0.1` after the merge of this PR.