### PR TITLE
feat: let `OutgoingMessage` implement `BufferList` interface

### DIFF
--- a/lib/outgoing_message.ts
+++ b/lib/outgoing_message.ts
@@ -14,7 +14,7 @@ import { SegmentedTransmission } from './segmentation'
 import IncomingMessage from './incoming_message'
 import { OptionName, Packet } from 'coap-packet'
 
-export default class OutgoingMessage extends BufferList {
+export default class OutgoingMessage extends BufferList implements BufferList {
     _packet: Packet
     _ackTimer: NodeJS.Timeout | null
     _send: (req: OutgoingMessage, packet: Packet) => void


### PR DESCRIPTION
This PR lets the `OutgoingMessage` transitively implement the `Duplex` interface from the `readable-stream` module by adding an implementation of the `BufferList` interface. This fixes compatibility issues with Node.js stream functions (and incorporates a recent [update](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57052) of the respective types module).

This PR is related to [this issue](https://github.com/eclipse/thingweb.node-wot/issues/642) in the [node-wot](https://github.com/eclipse/thingweb.node-wot) repository.

The PR does not change any functionality, therefore the CI should stay green.