### PR TITLE
Improve close logic and fix corner cases

### DIFF
--- a/test/agent.ts
+++ b/test/agent.ts
@@ -59,6 +59,15 @@ describe('Agent', function () {
             confirmable
         }).end()
     }
+    it('should exit with no requests in flight', function (done) {
+        agent.on('close', () => {
+            expect(agent._requests).to.equal(0)
+            expect(agent._sock).to.equal(null)
+            done()
+        })
+
+        agent.close()
+    }).timeout(500)
 
     it('should allow to close the agent', function (done) {
         let closeEmitted = false
@@ -75,13 +84,16 @@ describe('Agent', function () {
             expect(agent._sock).to.equal(null)
         })
 
-        agent.close()
+        agent.close(() => {
+            expect(agent._requests).to.equal(0)
+            expect(agent._sock).to.equal(null)
 
-        // Ensure that new requests can still be sent
-        doReq()
-        server.on('message', (msg, rsinfo) => {
-            expect(closeEmitted).to.equal(true)
-            agent.close(done)
+            // Ensure that new requests can still be sent
+            doReq()
+            server.on('message', (msg, rsinfo) => {
+                expect(closeEmitted).to.equal(true)
+                agent.close(done)
+            })
         })
     })
 

--- a/test/request.ts
+++ b/test/request.ts
@@ -142,6 +142,8 @@ describe('request', function () {
             ackBack(msg, rsinfo)
             done()
         })
+
+        server2.on('error', done)
     })
 
     it('should send the path to the server', function (done) {


### PR DESCRIPTION
Hello, this is my first PR to this repository let me know if I have to change the commit style or if I skipped some steps. Regarding the PR I'm coming from https://github.com/eclipse/thingweb.node-wot/issues/637 where we found that node hanged after using coap client.  I've dug into the code and I found out that the problem arises when you close an `agent` when there are no pending requests running. Basically if you take a look at the current implementation code:
```ts
 close (done?: (err?: Error) => void): this {
        for (const req of this._msgIdToReq.values()) {
            this.abort(req) // <-- never called if this._msgIdToReq.size === 0
        }
        if (done != null) {
            setImmediate(done)
        }
        return this
    }
```
The abort function is never called which in the end has the effect of not properly closing the socket. Net result? node hangs and does not exit. 

This PR fix this shortcoming and a couple of other details:
1. `done` function is only called after the socket is really closed
2. It adds a listener for errors in a test (on my machine whiteout that listener the test suite does not continue)

**Warning** after a clean clone on windows with node 14.17.0 I have a couple of tests that are still failing, this PR does not fix those. 