### PR TITLE
fix: fix problem with (boolean) observe parameters

### DIFF
--- a/models/models.ts
+++ b/models/models.ts
@@ -87,7 +87,7 @@ export interface CoapRequestParams {
     port?: number
     method?: CoapMethod
     confirmable?: boolean
-    observe?: 0 | 1 | boolean
+    observe?: 0 | 1 | boolean | string
     pathname?: string
     query?: string
     options?: Partial<Record<OptionName, OptionValue>>


### PR DESCRIPTION
This PR (probably) fixes an issue raised in https://github.com/iobroker-community-adapters/ioBroker.philips-air/issues/15 (I think). It seems as if https://github.com/mcollina/node-coap/pull/309 broke handling of the observe option as the value provided by the user is converted into a numeric one while the internal check expects a boolean. I am not entirely sure, yet, if this is the actual fix for the problem but it is probably a step into the right direction.