### PR TITLE
fix: move bl and lru-cache types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coap",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A CoAP library for node modelled after 'http'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chai": "^4.3.0",
     "@types/debug": "^4.1.7",
     "@types/mocha": "^9.1.0",
+    "@types/node": "^17.0.10",
     "@types/sinon": "^10.0.8",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "chai": "^4.3.4",
@@ -59,7 +60,6 @@
   "dependencies": {
     "@types/bl": "^5.0.2",
     "@types/lru-cache": "^5.1.1",
-    "@types/node": "^17.0.10",
     "bl": "^5.0.0",
     "capitalize": "^2.0.4",
     "coap-packet": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
   "license": "MIT",
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@types/bl": "^5.0.2",
     "@types/capitalize": "^2.0.0",
     "@types/chai": "^4.3.0",
     "@types/debug": "^4.1.7",
-    "@types/lru-cache": "^5.1.1",
     "@types/mocha": "^9.1.0",
     "@types/sinon": "^10.0.8",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -59,6 +57,8 @@
     "typescript": "~4.4.4"
   },
   "dependencies": {
+    "@types/bl": "^5.0.2",
+    "@types/lru-cache": "^5.1.1",
     "@types/node": "^17.0.10",
     "bl": "^5.0.0",
     "capitalize": "^2.0.4",


### PR DESCRIPTION
This PR fixes a typescript related issue raised in https://github.com/eclipse/thingweb.node-wot/issues/728 where the types for the `bl` and `lru-cache` modules could not be found during transpilation.