### PR TITLE
fix(agent): fix bug in observe option check

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -516,7 +516,7 @@ class Agent extends EventEmitter {
             req.setOption('Observe', url.observe)
         } else if (typeof (url.observe) === 'string') {
             req.setOption('Observe', parseInt(url.observe))
-        } else if (url.observe === true || url.observe != null) {
+        } else if (url.observe === true) {
             req.setOption('Observe', 0)
         } else {
             req.on('response', this._cleanUp.bind(this))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coap",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A CoAP library for node modelled after 'http'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
While #330 mostly fixed the problems with the observe request parameter, it also introduced a new bug that caused the Agent to always set the observe option to 0 in requests. This PR fixes the issue, making the Agent behave normally again.