### PR TITLE
chore: replace nyc with c8 for code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b",
     "pretest": "npm run build",
     "prepublishOnly": "npm run build",
-    "test": "nyc mocha ./dist/test --exit",
-    "coverage": "nyc report --reporter=lcov --reporter=text-summary",
+    "test": "c8  mocha ./dist/test --exit",
+    "coverage": "c8  report --reporter=lcov --reporter=text-summary",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -34,7 +34,6 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/capitalize": "^2.0.0",
     "@types/chai": "^4.3.0",
     "@types/debug": "^4.1.7",
@@ -49,7 +48,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.2.0",
     "mocha": "^9.2.0",
-    "nyc": "^15.1.0",
+    "c8": "^7.11.0",
     "pre-commit": "1.2.2",
     "sinon": "^12.0.1",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
Having a look at [coveralls.io](https://coveralls.io/github/mcollina/node-coap), I noticed that code coverage seems to be a bit broken right now. I recently found a better tool than nyc called c8 that seems to work with V8's native code coverage capabilities and be used as a drop-in replacement, fixing typescript related issues with nyc. It also gets rid of one additional dev-dependency.