### PR TITLE
fix: fix IPv6 related multicast problem

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -259,7 +259,7 @@ class CoAPServer extends EventEmitter {
                             multicastAddress,
                             this._multicastInterface
                         )
-                    } else {
+                    } else if (this._options.type === 'udp4') {
                         allAddresses(this._options.type).forEach((
                             _interface
                         ) => {
@@ -268,6 +268,10 @@ class CoAPServer extends EventEmitter {
                                 _interface
                             )
                         })
+                    } else {
+                        // FIXME: Iterating over all network interfaces does not
+                        //        work for IPv6 at the moment
+                        sock.addMembership(multicastAddress)
                     }
                 }
             } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coap",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A CoAP library for node modelled after 'http'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/server.ts
+++ b/test/server.ts
@@ -1014,6 +1014,12 @@ describe('server', function () {
 
         testVector.forEach(({ addressType, multicastAddress, type }) => {
             it(`receive ${addressType} CoAP message`, function (done) {
+                if (addressType === 'IPv6' && process.platform === 'darwin') {
+                    // FIXME: IPv6 multicast seems to have problems on macos
+                    //        at the moment
+                    this.skip()
+                }
+
                 const server = createServer({
                     multicastAddress,
                     type


### PR DESCRIPTION
I noticed that there is a problem with IPv6 multicast addresses in the server right now. This PR adds a test case to illustrate the problem and a workaround to fix it, as iterating over all IPv6 interfaces does not work as it does in the IPv4 case.

The new test is skipped in the case of Mac OS as there seem to be problems related to IPv6 multicast (`addMembership EADDRNOTAVAIL`).