### PR TITLE
docs: describe compatible node versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If you need a command line interface for CoAP, check out
 
 **node-coap** is an **OPEN Open Source Project**, see the <a href="#contributing">Contributing</a> section to find out what this means.
 
+The library *should* run on Node versions 10 and above but is only tested with LTS versions (currently 12, 14, and 16).
+
 <a name="install"></a>
 ## Installation
 


### PR DESCRIPTION
As we only test for node 12 and above at the moment, it probably makes sense to only test for these versions. As soon as node 12 is EOL, we should bump the version to 14.