### PR TITLE
chore: exclude TS source files from publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,13 @@
   },
   "engines": {
     "node": ">=10"
-  }
+  },
+  "files": [
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/models",
+    "dist/lib",
+    "examples/"
+  ]
 }


### PR DESCRIPTION
At the moment, we also publish the Typescript source files when uploading to npm which increases the bundle size. This PR would exclude them from publishing. However, also including the source files potentially makes debugging easier for users of the library.

Do you think we should remove the source files? Then we could simply merge this PR. Or should we keep them?