### PR TITLE
fix: fix problem with observe responses without observe option

### DIFF
--- a/examples/observe_eclipse.js
+++ b/examples/observe_eclipse.js
@@ -1,0 +1,29 @@
+const coap = require('../') // or coap
+
+const statusRequest = coap.request({
+    method: 'GET',
+    host: 'californium.eclipseprojects.io',
+    pathname: 'obs',
+    observe: true,
+    confirmable: true
+})
+
+let responseCounter = 0
+
+statusRequest.on('response', res => {
+    res.on('error', err => {
+        console.error('Error by receiving: ' + err)
+        this.emit('error', 'Error by receiving: ' + err)
+        res.close()
+    })
+
+    res.on('data', chunk => {
+        console.log(`Server time: ${chunk.toString()}`)
+        responseCounter++
+        if (responseCounter >= 5) {
+            console.log('Successfully received five responses. Closing the ObserveStream.')
+            res.close()
+        }
+    })
+})
+statusRequest.end()

--- a/lib/observe_read_stream.ts
+++ b/lib/observe_read_stream.ts
@@ -33,20 +33,24 @@ export default class ObserveReadStream extends IncomingMessage {
             packetToMessage(this, packet)
         }
 
+        let observe: number
+
         if (typeof this.headers.Observe !== 'number') {
-            return
+            observe = 0
+        } else {
+            observe = this.headers.Observe
         }
 
         // First notification
         if (this._lastId === undefined) {
-            this._lastId = this.headers.Observe - 1
+            this._lastId = observe - 1
         }
 
-        const dseq = (this.headers.Observe - this._lastId) & 0xffffff
+        const dseq = (observe - this._lastId) & 0xffffff
         const dtime = Date.now() - this._lastTime
 
         if (this._disableFiltering || (dseq > 0 && dseq < (1 << 23)) || dtime > 128 * 1000) {
-            this._lastId = this.headers.Observe
+            this._lastId = observe
             this._lastTime = Date.now()
             this.push(packet.payload)
         }

--- a/test/request.ts
+++ b/test/request.ts
@@ -1390,7 +1390,7 @@ describe('request', function () {
                         return
                     }
 
-                    server.on('message', (msg, rsinfo) => {
+                    server.once('message', (msg, rsinfo) => {
                         const packet = parse(msg)
                         if (packet.ack && (packet.code === '0.00')) {
                             return

--- a/test/request.ts
+++ b/test/request.ts
@@ -1262,6 +1262,14 @@ describe('request', function () {
                         token: packet.token,
                         payload: Buffer.from('42'),
                         ack: true,
+                        code: '2.05'
+                    })
+
+                    ssend(rsinfo, {
+                        messageId: packet.messageId,
+                        token: packet.token,
+                        payload: Buffer.from('42'),
+                        ack: true,
                         options: [{
                             name: 'Observe',
                             value: Buffer.of(1)


### PR DESCRIPTION
With this PR I think I finally found the fix for https://github.com/iobroker-community-adapters/ioBroker.philips-air/issues/15: As it turned out, a type check that I had introduced to make sure that only numeric Observe values are passed to the initialization of `ObserveStream` objects caused them to not be initialized at all.

This PR fixes the issue and illustrates that observing now finally works again with an example using the Eclipse Californium test server.