### PR TITLE
fix: encode 0 in observe option with zero byte length

### DIFF
--- a/models/models.ts
+++ b/models/models.ts
@@ -16,7 +16,7 @@ import CoAPServer from '../lib/server'
 
 export declare function requestListener (req: IncomingMessage, res: OutgoingMessage): void
 
-export type OptionValue = string | number | Buffer | Buffer[]
+export type OptionValue = null | string | number | Buffer | Buffer[]
 export type BlockCacheMap<T> = Map<string, {payload: T, timeoutId: NodeJS.Timeout}>
 export type CoapOptions = Partial<Record<OptionName, OptionValue>>
 

--- a/test/request.ts
+++ b/test/request.ts
@@ -1422,7 +1422,7 @@ describe('request', function () {
             server.on('message', (msg, rsinfo) => {
                 const packet = parse(msg)
                 expect(packet.options[0].name).to.eql('Observe')
-                expect(packet.options[0].value).to.eql(Buffer.of(0))
+                expect(packet.options[0].value).to.eql(Buffer.alloc(0))
                 done()
             })
         })

--- a/test/server.ts
+++ b/test/server.ts
@@ -1320,7 +1320,7 @@ describe('Client Identifier', function () {
                     authenticationHeader = request._packet.options.find(o => o.name === 2109)
                 }
 
-                if (typeof authenticationHeader !== 'undefined') {
+                if (authenticationHeader?.value != null) {
                     return `auth:${authenticationHeader.value.toString()}`
                 }
                 return `unauth:${request.rsinfo.address}:${request.rsinfo.port}`


### PR DESCRIPTION
This PR should finally fix the issues reported in https://github.com/iobroker-community-adapters/ioBroker.philips-air/issues/15 by encoding a value of zero in observe options with a length of zero bytes (as it has been the case before).