### PR TITLE
fix(agent): correctly handle `false` observe values

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -524,7 +524,7 @@ class Agent extends EventEmitter {
     _setObserveOption (req: OutgoingMessage, requestParameters: CoapRequestParams): void {
         const observeParameter = requestParameters.observe
 
-        if (observeParameter == null) {
+        if (observeParameter == null || observeParameter === false) {
             req.on('response', this._cleanUp.bind(this))
             return
         }


### PR DESCRIPTION
This is a fix for https://github.com/avency/coap-cli/issues/136. The case where the `observe` parameter is set to `false` has not been handled correctly, yet, causing clients to hang after a request has been finished.