### PR TITLE
fix: correctly clear timeout in `BlockCache` class

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -70,12 +70,11 @@ class BlockCache<T> {
     }
 
     remove (key: string): boolean {
-        if (this._cache.delete(key)) {
+        if (this.contains(key)) {
             debug('remove cache entry, key:', key)
             this.clearTimeout(key)
-            return true
         }
-        return false
+        return this._cache.delete(key)
     }
 
     contains (key: string): boolean {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coap",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A CoAP library for node modelled after 'http'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
In the context of https://github.com/eclipse/thingweb.node-wot/pull/846, I noticed that the server is currently not cleaning up timeouts in the `BlockCache` class correctly. This PR implements a simple fix.